### PR TITLE
Rename to Decapodes.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "Decapods"
+name = "Decapodes"
 uuid = "679ab3ea-c928-4fe6-8d59-fd451142d391"
 authors = ["James Fairbanks", "Andrew Baas", "Evan Patterson"]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Decapods.jl
-[![Documentation](https://github.com/AlgebraicJulia/Decapods.jl/workflows/Documentation/badge.svg)](https://algebraicjulia.github.io/Decapods.jl/dev/)
-![Tests](https://github.com/AlgebraicJulia/Decapods.jl/workflows/Tests/badge.svg)
+# Decapodes.jl
+[![Documentation](https://github.com/AlgebraicJulia/Decapodes.jl/workflows/Documentation/badge.svg)](https://algebraicjulia.github.io/Decapodes.jl/dev/)
+![Tests](https://github.com/AlgebraicJulia/Decapodes.jl/workflows/Tests/badge.svg)
 
-Decapods are a graphical tool for the composition of physical systems.
+Decapodes are a graphical tool for the composition of physical systems.
 Ultimately, this library will include tooling which takes advantage of the
 formalization of physical theories described by DEC provided by
 [CombinatorialSpaces.jl](https://algebraicjulia.github.io/CombinatorialSpaces.jl/dev/).

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
-Decapods = "679ab3ea-c928-4fe6-8d59-fd451142d391"
+Decapodes = "679ab3ea-c928-4fe6-8d59-fd451142d391"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DynamicalSystems = "61744808-ddfa-5f27-97ff-6e42cc95d634"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,16 +1,16 @@
 using Documenter
 using Literate
 
-@info "Loading Decapods"
-using Decapods
+@info "Loading Decapodes"
+using Decapodes
 using Catlab
 using Catlab.WiringDiagrams
 
 # Set Literate.jl config if not being compiled on recognized service.
 config = Dict{String,String}()
 if !(haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "GITLAB_CI"))
-  config["nbviewer_root_url"] = "https://nbviewer.jupyter.org/github/AlgebraicJulia/Decapods.jl/blob/gh-pages/dev"
-  config["repo_root_url"] = "https://github.com/AlgebraicJulia/Decapods.jl/blob/main/docs"
+  config["nbviewer_root_url"] = "https://nbviewer.jupyter.org/github/AlgebraicJulia/Decapodes.jl/blob/gh-pages/dev"
+  config["repo_root_url"] = "https://github.com/AlgebraicJulia/Decapodes.jl/blob/main/docs"
 end
 
 #const literate_dir = joinpath(@__DIR__, "..", "examples")
@@ -31,15 +31,15 @@ end
 
 @info "Building Documenter.jl docs"
 makedocs(
-  modules   = [Decapods],
+  modules   = [Decapodes],
   format    = Documenter.HTML(
     assets = ["assets/analytics.js"],
   ),
-  sitename  = "Decapods.jl",
+  sitename  = "Decapodes.jl",
   doctest   = false,
   checkdocs = :none,
   pages     = Any[
-    "Decapods.jl" => "index.md",
+    "Decapodes.jl" => "index.md",
 #    "Examples" => Any[
 #      "examples/cfd_example.md"
 #    ],
@@ -50,7 +50,7 @@ makedocs(
 @info "Deploying docs"
 deploydocs(
   target = "build",
-  repo   = "github.com/AlgebraicJulia/Decapods.jl.git",
+  repo   = "github.com/AlgebraicJulia/Decapodes.jl.git",
   branch = "gh-pages",
   devbranch = "main"
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,6 @@
 
 ## Tonti Diagrams
 ```@autodocs
-Modules = [ Decapods.TontiDiagrams ]
+Modules = [ Decapodes.TontiDiagrams ]
 Private = false
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
-# Decapods.jl
+# Decapodes.jl
 
-Decapods are a graphical tool for the composition of physical systems.
+Decapodes are a graphical tool for the composition of physical systems.
 Ultimately, this library will include tooling which takes advantage of the
 formalization of physical theories described by DEC provided by
 [CombinatorialSpaces.jl](https://algebraicjulia.github.io/CombinatorialSpaces.jl/dev/).

--- a/examples/cfd_example.jl
+++ b/examples/cfd_example.jl
@@ -12,7 +12,7 @@ using CombinatorialSpaces: ∧
 using Distributions
 using CairoMakie
 using DifferentialEquations
-using Decapods.TontiDiagrams
+using Decapodes.TontiDiagrams
 
 using Logging: global_logger
 using TerminalLoggers: TerminalLogger

--- a/examples/decapods/decapods_example.jl
+++ b/examples/decapods/decapods_example.jl
@@ -8,15 +8,15 @@ using Catlab.Graphics
 using Catlab.CategoricalAlgebra
 using LinearAlgebra
 
-using Decapods.Simulations
-using Decapods.Examples
-using Decapods.Diagrams
-using Decapods.Schedules
+using Decapodes.Simulations
+using Decapodes.Examples
+using Decapodes.Diagrams
+using Decapodes.Schedules
 
 # Julia community libraries
 using MeshIO
 using CairoMakie
-using Decapods.Debug
+using Decapodes.Debug
 using DifferentialEquations
 using Logging: global_logger
 using TerminalLoggers: TerminalLogger

--- a/examples/diffusion_composition.ipynb
+++ b/examples/diffusion_composition.ipynb
@@ -168,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "using Decapods.OpenDiagrams\n",
+    "using Decapodes.OpenDiagrams\n",
     "\n",
     "composed_diffusion = oapply(compose_diffusion, [\n",
     "    OpenDiagram(FicksLaw2D, [:C, :J]),\n",

--- a/examples/diffusion_diags.jl
+++ b/examples/diffusion_diags.jl
@@ -26,16 +26,16 @@ DiffusionConservation2D = @free_diagram DiffusionSpace2D begin
   Ċ == ⋆₀⁻¹{X}(dϕ)
 end;
 
-using Decapods
+using Decapodes
 
 compose_diffusion = @relation (C, Ċ, ϕ) begin
   ficks_law(C, ϕ)
   mass_conservation(C, Ċ, ϕ)
 end
 
-Decapods.OpenDiagrams.draw(compose_diffusion)
+Decapodes.OpenDiagrams.draw(compose_diffusion)
 
-using Decapods.OpenDiagrams
+using Decapodes.OpenDiagrams
 
 composed_diffusion = oapply(compose_diffusion, [
     OpenDiagram(FicksLaw2D, [:C, :J]),

--- a/src/Decapodes.jl
+++ b/src/Decapodes.jl
@@ -1,4 +1,4 @@
-module Decapods
+module Decapodes
 
 using Requires
 

--- a/src/Examples.jl
+++ b/src/Examples.jl
@@ -8,9 +8,9 @@ using Catlab.Programs
 using Catlab.WiringDiagrams
 using Catlab.Graphics
 using Catlab.CategoricalAlgebra
-using Decapods.Simulations
-using Decapods.Diagrams
-using Decapods.Schedules
+using Decapodes.Simulations
+using Decapodes.Diagrams
+using Decapodes.Schedules
 using CombinatorialSpaces: ∧
 
 using LinearAlgebra

--- a/test/Decapodes.jl
+++ b/test/Decapodes.jl
@@ -1,4 +1,4 @@
-module DecapodsTest
+module DecapodesTest
 
   using Catlab
 	using Catlab.Present
@@ -9,11 +9,11 @@ module DecapodsTest
   using LinearAlgebra
   using Test
 
-	using Decapods.Simulations
-	using Decapods.Diagrams
-	using Decapods.Schedules
-	using Decapods.OpenDiagrams
-	using Decapods.Examples
+	using Decapodes.Simulations
+	using Decapodes.Diagrams
+	using Decapodes.Schedules
+	using Decapodes.OpenDiagrams
+	using Decapodes.Examples
   using Random
 
 	@present DiffusionSpace2D(FreeExtCalc2D) begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
 
-@testset "Decapods" begin
-  include("Decapods.jl")
+@testset "Decapodes" begin
+  include("Decapodes.jl")
 end


### PR DESCRIPTION
This PR renames the Julia package to Decapodes.jl to align better with the acronym:
Discrete Exterior Calculus Applied to Partial and Ordinary Differential Equations (DECAPODE)