### PR TITLE
Added interop tooling for PetriNets into Decapods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,9 +18,10 @@ CombinatorialSpaces = "0.3"
 julia = "1.0"
 
 [extras]
+AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "GeometryBasics"]
+test = ["AlgebraicPetri", "Test", "Random", "GeometryBasics"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["James Fairbanks", "Andrew Baas", "Evan Patterson"]
 version = "0.1.0"
 
 [deps]
-AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 CombinatorialSpaces = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/src/Decapodes.jl
+++ b/src/Decapodes.jl
@@ -10,5 +10,6 @@ include("Examples.jl")
 
 function __init__()
   @require CairoMakie="13f3f980-e62b-5c42-98c6-ff1f3baf88f0" include("Debug.jl")
+  @require AlgebraicPetri="4f99eebe-17bf-4e98-b6a1-2c4f205a959b" include("PetriNets.jl")
 end
 end

--- a/src/Diagrams.jl
+++ b/src/Diagrams.jl
@@ -3,361 +3,147 @@ module Diagrams
 using CombinatorialSpaces.ExteriorCalculus
 using Catlab
 using Catlab.CategoricalAlgebra
-using Catlab.Graphics
-import Catlab.Graphics: to_graphviz
-using Catlab.Graphs
 using Catlab.Theories
-using AlgebraicPetri
-import AlgebraicPetri: Graph
+using Catlab.Programs.DiagrammaticPrograms: parse_diagram, parse_gat_expr
+using Unicode
 
-export eq_to_diagrams, FreeElDiagram, to_graphviz, ElPetriNet, Graph
+export @decapode
 
-# Diagram of Elements from equations
-####################################
-
-@present ThElDiagram <: ThElements begin
-  namee::Attr(El, Name)
-  namea::Attr(Arr, Name)
-end
-@acset_type FreeElDiagram(ThElDiagram, index=[:src,:tgt, :dom, :cod])
-
-
-function add_el!(ce::FreeElDiagram, otype)
-  o = vcat(incident(ce, [otype], :nameo)...)
-  if isempty(o)
-    o = [add_part!(ce, :Ob, nameo = otype)]
-  end
-  add_part!(ce, :El, namee = Symbol("anon_",gensym()), πₑ=first(o))
+macro decapode(cat, body)
+  :(parse_exp_diagram($(esc(cat)), $(Meta.quot(body)), free=true))
 end
 
-function add_els!(ce::FreeElDiagram, obs)
-  map(o -> add_el!(ce, o), obs)
-end
-
-function add_arr!(ce::FreeElDiagram, htype, src, tgt)
-  h = vcat(incident(ce, [htype], :nameh)...)
-  if isempty(h)
-    h = [add_part!(ce, :Hom, nameh = htype, dom=ce[src, :πₑ], cod=ce[tgt, :πₑ])]
-  end
-  add_part!(ce, :Arr, namea = Symbol(htype), src=src, tgt=tgt, πₐ = first(h))
-end
-
-function add_arrs!(ce::FreeElDiagram, homs, srcs, tgts)
-  map(i -> add_arr!(ce, homs[i], srcs[i], tgts[i]), 1:length(homs))
-end
-
-sp_otimes(expr, syntax) = expr isa syntax.Ob{:otimes} ? expr.args : [expr]
-
-function m_proj_n(syntax, n, expr)
-  #left = isempty(1:(n-1)) ? [] : syntax.proj2(foldl(⊗, expr.args[1:n-1]), foldl(⊗, expr.args[n:end]))
-  #right = isempty((n+1):length(expr.args)) ? [] : syntax.proj1(expr.args[n], foldl(⊗, expr.args[(n+1):end]))
-  #foldl(⋅, vcat(left, right))
-  Symbol("π$n")
-end
-
-function add_term!(ce::FreeElDiagram, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-  add_term!(Val{h}, ce, in_els, term, syntax; h=h, a=a)
-end
-
-function add_term!(::Type{Val{:compose}}, ce::FreeElDiagram, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-  cur_obs = in_els
-  for arg in a
-    cur_obs = add_term!(ce, cur_obs, arg, syntax)
-  end
-  cur_obs
-end
-
-function add_term!(::Type{Val{:otimes}}, ce::FreeElDiagram, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-    new_obs = [add_els!(ce, ce[ce[in_els, :πₑ], :nameo]) for i in 1:length(a)]
-    map(i -> add_arrs!(ce, syntax.mcopy.(ce[ce[in_els, :πₑ], :nameo]), in_els, new_obs[i]), 1:length(a))
-    up_obs = vcat(map(i -> add_term!(ce, collect(new_obs[i]), a[i], syntax), 1:length(a))...)
-end
-
-function add_term!(::Type{Val{:plus}}, ce::FreeElDiagram, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-    new_obs = add_term!(ce, in_els, term, syntax; h=:otimes)
-    op_types = sp_otimes(codom(first(a)), syntax)
-    doub_types = op_types .⊗ op_types
-    comb_els = add_els!(ce, doub_types)
-    n_ops = length(op_types)
-    map(n -> add_arrs!(ce, [Symbol("a", i + (n-1)*n_ops) for i in 1:n_ops], new_obs[(1:n_ops) .+ (n-1)*n_ops], comb_els), 1:length(a))
-    out_obs = add_els!(ce, op_types)
-    add_arrs!(ce, [syntax.plus(o) for o in op_types], comb_els, out_obs)
-    out_obs
-end
-
-function add_term!(::Type{<:Val}, ce::FreeElDiagram, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-    d_args = sp_otimes(dom(term), syntax)
-    c_args = sp_otimes(codom(term), syntax)
-    inp = first(in_els)
-    if length(d_args) > 1
-      inp = add_el!(ce, dom(term))
-      add_arrs!(ce, [Symbol("a", i) for i in 1:length(in_els)], in_els, fill(inp, length(in_els)))
-    end
-    otp = add_el!(ce, codom(term))
-    add_arr!(ce, term, inp, otp)
-    otps = [otp]
-    if length(c_args) > 1
-      otps = add_els!(ce, c_args)
-      add_arrs!(ce, [m_proj_n(syntax, i, ce[ce[otp, :πₑ], :nameo]) for i in 1:length(in_els)], fill(otp, length(otps)), otps)
-    end
-    otps
-end
-
-
-
-function rem_units!(ce::FreeElDiagram, syntax)
-  munits = findall(x -> x isa syntax.Ob{:munit}, ce[:nameo])
-  unit_els = vcat(incident(ce, munits,:πₑ)...)
-  if isempty(unit_els)
-    return
-  end
-  i_wires = vcat(incident(ce, unit_els, :src)...)
-
-  o_wires = vcat(incident(ce, unit_els, :tgt)...)
-
-  ce[ce[i_wires, :tgt], :namee] .= ce[i_wires, :namea]
-  ce[ce[o_wires, :src], :namee] .= ce[o_wires, :namea]
-
-  rem_parts!(ce, :El, sort(unit_els))
-  rem_parts!(ce, :Arr, sort(unique(vcat(i_wires, o_wires))))
-end
-
-function merge_nodes!(ce::FreeElDiagram, args)
-  source_node = first(args)
-
-  i_wires = vcat(incident(ce, args, :src)...)
-  o_wires = vcat(incident(ce, args, :tgt)...)
-
-  set_subparts!(ce, i_wires, src = source_node)
-  set_subparts!(ce, o_wires, tgt = source_node)
-
-  rem_parts!(ce, :El, sort(unique(args[2:end])))
-end
-
-function merge_pairs!(ce::FreeElDiagram, left, right)
-  i_wires = incident(ce, right, :src)
-  o_wires = incident(ce, right, :tgt)
-  for i in 1:length(left)
-    set_subparts!(ce, i_wires[i], src = left[i])
-    set_subparts!(ce, o_wires[i], tgt = left[i])
-  end
-  rem_parts!(ce, :El, sort(unique(right)))
-end
-
-function merge_common!(ce::FreeElDiagram)
-  names = ce[:namee]
-  for n in names
-    vals = incident(ce, n, :namee)
-    if length(vals) > 1
-      merge_nodes!(ce, vals)
+function parse_exp_diagram(cat, body; kw...)
+  objs = filter(exp -> !(exp isa LineNumberNode) && (exp.head == :(::)), body.args)
+  obj_map = Dict{Symbol, Expr}()
+  for obj in objs
+    names = obj.args[1]
+    type = obj.args[2]
+    # Expand if object is a tuple or single object
+    if names isa Symbol
+      obj_map[names] = type
+    else
+      for name in names.args
+        obj_map[name] = type
+      end
     end
   end
-end
-
-function to_graphviz(fd::FreeElDiagram; edge_len=1.9)
-  nl(v) = (length(string(fd[v, :namee])) > 4 && string(fd[v, :namee])[1:4] == "anon") ? Dict(:shape => "point") : Dict(:label => "$(fd[v, :namee])")
-	el(e) = Dict(:label => "$(fd[e, :namea])", :len => "$edge_len")
-  g = Graphs.Graph()
-	migrate!(g, fd, Dict(:V=>:El, :E=>:Arr), Dict(:src=>:src, :tgt => :tgt))
-	to_graphviz(PropertyGraph{Any}(g, nl, el; prog="neato"))
-end
-
-# PetriNet of Elements
-######################
-
-# Need to add src/tgt information to Ob/Hom
-@present ThElPetriNet(FreeSchema) begin
-  Name::AttrType
-
-  El::Ob
-  Arr::Ob
-  Src::Ob
-  Tgt::Ob
-
-  Ob::Ob
-  Hom::Ob
-
-  πₑ::Hom(El, Ob)
-  πₐ::Hom(Arr, Hom)
-  se::Hom(Src, El)
-  sa::Hom(Src, Arr)
-  te::Hom(Tgt, El)
-  ta::Hom(Tgt, Arr)
-
-  namee::Attr(El, Name)
-  namea::Attr(Arr, Name)
-  nameo::Attr(Ob, Name)
-  nameh::Attr(Hom, Name)
-end
-@acset_type ElPetriNet(ThElPetriNet, index=[:se, :sa, :te, :ta])
-
-function add_el!(ce::ElPetriNet, otype)
-  o = vcat(incident(ce, [otype], :nameo)...)
-  if isempty(o)
-    o = [add_part!(ce, :Ob, nameo = otype)]
-  end
-  add_part!(ce, :El, namee = Symbol("anon_",gensym()), πₑ=first(o))
-end
-
-function add_els!(ce::ElPetriNet, obs)
-  map(o -> add_el!(ce, o), obs)
-end
-
-function add_arr!(ce::ElPetriNet, htype, srcs, tgts)
-  h = vcat(incident(ce, [htype], :nameh)...)
-  if isempty(h)
-    h = [add_part!(ce, :Hom, nameh = htype)]
-  end
-  arr = add_part!(ce, :Arr, namea = Symbol(htype), πₐ = first(h))
-  add_parts!(ce, :Src, length(srcs), se=srcs, sa=fill(arr, length(srcs)))
-  add_parts!(ce, :Tgt, length(tgts), te=tgts, ta=fill(arr, length(tgts)))
-  arr
-end
-
-function add_arrs!(ce, homs, srcs, tgts)
-  map(i -> add_arr!(ce, homs[i], srcs[i], tgts[i]), 1:length(homs))
-end
-
-function add_term!(ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-  add_term!(Val{h}, ce, in_els, term, syntax; h=h, a=a)
-end
-
-function add_term!(::Type{Val{:compose}}, ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-  cur_obs = in_els
-  for arg in a
-    cur_obs = add_term!(ce, cur_obs, arg, syntax)
-  end
-  cur_obs
-end
-
-function add_term!(::Type{Val{:otimes}}, ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-  vcat(map(i -> add_term!(ce, in_els, a[i], syntax), 1:length(a))...)
-end
-
-function add_term!(::Type{Val{:oplus}}, ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-  up_obs = map(i -> add_term!(ce, in_els, a[i], syntax), 1:length(a))
-
-  new_ob = add_el!(ce, foldl(⊕, [foldl(ExteriorCalculus.otimes, ce[ce[uo, :πₑ], :nameo]) for uo in up_obs]))
-  add_arrs!(ce, [Symbol(:π, i) for i in 1:length(up_obs)], fill([new_ob], length(up_obs)), [u for u in up_obs])
-  [new_ob]
-end
-
-function add_term!(::Type{Val{:plus}}, ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-    new_ob = add_term!(ce, in_els, term, syntax; h=:oplus)
-    out_ob = add_el!(ce, codom(term))
-    add_arr!(ce, syntax.plus(codom(term)), new_ob, [out_ob])
-    [out_ob]
-end
-
-function add_term!(::Type{Val{:generator}}, ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-    d_args = sp_otimes(dom(term), syntax)
-    c_args = sp_otimes(codom(term), syntax)
-
-    codom_obs = add_els!(ce, c_args)
-    add_arr!(ce, a[1], in_els, codom_obs)
-
-    codom_obs
-end
-
-function add_term!(::Type{<:Val}, ce::ElPetriNet, in_els::Vector{Int}, term, syntax; h=head(term), a=args(term))
-    d_args = sp_otimes(dom(term), syntax)
-    c_args = sp_otimes(codom(term), syntax)
-
-    codom_obs = add_els!(ce, c_args)
-    add_arr!(ce, h, in_els, codom_obs)
-
-    codom_obs
-end
-
-
-
-function rem_units!(ce::ElPetriNet, syntax)
-  munits = findall(x -> x isa syntax.Ob{:munit}, ce[:nameo])
-  unit_els = vcat(incident(ce, munits,:πₑ)...)
-  if isempty(unit_els)
-    return
-  end
-  i_wires = copy(ce[vcat(incident(ce, unit_els, :se)...), :sa])
-  o_wires = copy(ce[vcat(incident(ce, unit_els, :te)...), :ta])
-
-  i_els = ce[vcat(incident(ce, i_wires, :ta)...), :te]
-  o_els = ce[vcat(incident(ce, o_wires, :sa)...), :se]
-
-  ce[i_els, :namee] .= ce[i_wires, :namea]
-  ce[o_els, :namee] .= ce[o_wires, :namea]
-
-  rem_parts!(ce, :Src, sort(vcat(incident(ce, unit_els, :se)...)))
-  rem_parts!(ce, :Tgt, sort(vcat(incident(ce, unit_els, :te)...)))
-  rem_parts!(ce, :El, sort(unit_els))
-  del_wires = unique(vcat(i_wires, o_wires))
-  rem_parts!(ce, :Src, sort(vcat(incident(ce, del_wires, :sa)...)))
-  rem_parts!(ce, :Tgt, sort(vcat(incident(ce, del_wires, :ta)...)))
-  rem_parts!(ce, :Arr, sort(del_wires))
-end
-
-function merge_nodes!(ce::ElPetriNet, args)
-  source_node = first(args)
-
-  i_wires = vcat(incident(ce, args, :se)...)
-  o_wires = vcat(incident(ce, args, :te)...)
-
-  set_subparts!(ce, i_wires, se = source_node)
-  set_subparts!(ce, o_wires, te = source_node)
-
-  rem_parts!(ce, :El, sort(unique(args[2:end])))
-end
-
-function merge_pairs!(ce::ElPetriNet, left, right)
-
-  i_wires = incident(ce, right, :se)
-  o_wires = incident(ce, right, :te)
-  for i in 1:length(left)
-    set_subparts!(ce, i_wires[i], se = left[i])
-    set_subparts!(ce, o_wires[i], te = left[i])
-  end
-  rem_parts!(ce, :El, sort(unique(right)))
-end
-
-function merge_common!(ce::ElPetriNet)
-  names = ce[:namee]
-  for n in names
-    vals = incident(ce, n, :namee)
-    if length(vals) > 1
-      merge_nodes!(ce, vals)
+  new_body = quote end
+  for exp in body.args
+    if !(exp isa LineNumberNode) && exp.head == :call && exp.args[1] == :(==)
+      exprs = []
+      if exp.args[2] isa Symbol
+        res, _ = expand_expr!(exprs, exp.args[3], cat, obj_map; make_var = false)
+        push!(exprs, :($(exp.args[2]) == $(res)))
+      elseif exp.args[3] isa Symbol
+        res, _ = expand_expr!(exprs, exp.args[2], cat, obj_map; make_var = false)
+        push!(exprs, :($(exp.args[3]) == $(res)))
+      else
+        res1, _ = expand_expr!(exprs, exp.args[2], cat, obj_map; make_var = true)
+        res2, _ = expand_expr!(exprs, exp.args[3], cat, obj_map; make_var = false)
+        push!(exprs, :($(res1) == $(res2)))
+      end
+      append!(new_body.args, exprs)
+    else
+      push!(new_body.args, exp)
     end
   end
+  parse_diagram(cat, new_body; kw...)
 end
 
-function Graph(ep::ElPetriNet)
-  pn = LabelledPetriNet()
-  migrate!(pn, ep, Dict(:S => :El, :T => :Arr, :I => :Src, :O => :Tgt),
-                   Dict(:is => :se, :os => :te, :it => :sa, :ot => :ta,
-                        :tname => :namea, :sname => :namee))
-  Graph(pn)
+i2sub = Dict(
+  '0'=>'₀', '1'=>'₁', '2'=>'₂', '3'=>'₃', '4'=>'₄', '5'=>'₅',
+  '6'=>'₆', '7'=>'₇', '8'=>'₈', '9'=>'₉', '-'=>'₋'
+)
+i2sup = Dict(
+  '0'=>'⁰', '1'=>'¹', '2'=>'²', '3'=>'³', '4'=>'⁴', '5'=>'⁵',
+  '6'=>'⁶', '7'=>'⁷', '8'=>'⁸', '9'=>'⁹', '-'=>'⁻'
+)
+
+form_sup(type::Expr) = form_sup(type.args[1])
+form_sub(type::Expr) = form_sub(type.args[1])
+
+form_sup(type::Symbol) = startswith("$type", "Dual") ?
+                                               i2sup[last("$type")] * '̃' :  i2sup[last("$type")]
+form_sub(type::Symbol) = startswith("$type", "Dual") ? i2sub[last("$type")] * '̃' : i2sub[last("$type")]
+
+
+# Currently every projection needs its own index
+function make_proj(ind, types)
+  op = "proj" * i2sub["$ind"[1]] * "_" * join(form_sup.(types)) * form_sub(types[ind])
+  Symbol(Unicode.normalize(op))
 end
 
-function eq_to_diagrams(d::Presentation; diagram=FreeElDiagram{Any}())
-  ce = diagram
-  for eq in equations(d)
-    first_ob = add_el!(ce, dom(eq[1]))
-    left = add_term!(ce, [first_ob], eq[1], d.syntax)
-    right = add_term!(ce, [first_ob], eq[2], d.syntax)
-    merge_pairs!(ce, left, right)
+function parse_type(type)
+  if head(type) == :otimes
+    Meta.parse("otimes{$(join(["$(head(t)){$(t.args[1])}" for t in type.args], ","))}")
+  else
+    Meta.parse("$(head(type)){$(type.args[1])}")
   end
-  rem_units!(ce, d.syntax)
-  merge_common!(ce)
-  ce
 end
 
-function to_monoidal(ep::ElPetriNet)
-  ep2 = deepcopy(ep)
 
-  proj_ind = findall(n -> first("$n") == 'π', ep[:namea])
-  map(proj_ind) do pa
-    proj_arrs = first(incident(ep, pa, :sa))
-    el = ep[first(incident(ep, pa, :sa)), :se]
-#    incident
+get_name(expr) = expr isa Symbol ? expr : get_name(expr.args[1])
+
+function expand_expr!(expr_arr, expr, cat, obj_map; make_var = true)
+  if expr isa Symbol
+    expr, obj_map[expr]
+  elseif length(expr.args) > 2
+    if expr.args[1] == :+
+      # Only process 2 of these at a time (sum first, evaluate second as sum)
+      res1 = expand_expr!(expr_arr, expr.args[2], cat, obj_map; make_var = true)
+
+      res2 = length(expr.args) > 3 ?
+      expand_expr!(expr_arr, :(+($(expr.args[3:end]...))), cat, obj_map; make_var = true) :
+              expand_expr!(expr_arr, expr.args[3], cat, obj_map; make_var = true)
+      type = res1[2]
+
+      sum_name = Symbol(Unicode.normalize("sum" * form_sub(type)))
+      new_var = gensym()
+      nv_type = :(otimes{$(res1[2]), $(res2[2])})
+      push!(expr_arr, :($(new_var)::$(nv_type)))
+      push!(expr_arr, :($(res1[1]) == $(make_proj(1, [res1[2], res2[2]]))($(new_var))))
+      push!(expr_arr, :($(res2[1]) == $(make_proj(2, [res1[2], res2[2]]))($(new_var))))
+      if make_var
+        name = gensym()
+        push!(expr_arr, :($(name)::$(type)))
+        push!(expr_arr, :($(name) == $(sum_name)($(new_var))))
+        name, type
+      else
+        :($(sum_name)($(new_var))), type
+      end
+    else
+      res = map(expr.args[2:end]) do ex
+        expand_expr!(expr_arr, ex, cat, obj_map; make_var = true)
+      end
+      new_var = gensym()
+      nv_type = Meta.parse("otimes{$(join(last.(res), ","))}")
+      push!(expr_arr, :($(new_var)::$(nv_type)))
+      append!(expr_arr, map(enumerate(res)) do (i, obj)
+                :($(obj[1]) == $(make_proj(i, last.(res)))($(new_var)))
+              end)
+      type = parse_type(codom(parse_gat_expr(FinCat(cat), expr.args[1])))
+      if make_var
+        name = gensym()
+        push!(expr_arr, :($(name)::$(type)))
+        push!(expr_arr, :($(name) == $(expr.args[1])($(new_var))))
+        name, type
+      else
+        :($(expr.args[1])($(new_var))), type
+      end
+    end
+  else
+    type = parse_type(codom(parse_gat_expr(FinCat(cat), expr.args[1])))
+    arg_var, arg_type = expand_expr!(expr_arr, expr.args[2], cat, obj_map; make_var = false)
+    expr.args[2] = arg_var
+    cur_var = expr
+    if make_var
+      name = gensym()
+      push!(expr_arr, :($(name)::$(type)))
+      push!(expr_arr, :($(name) == $(expr)))
+      cur_var = name
+    end
+    cur_var, type
   end
 end
-
 end

--- a/src/PetriNets.jl
+++ b/src/PetriNets.jl
@@ -1,0 +1,158 @@
+module PetriNets
+
+using Catlab, Catlab.CategoricalAlgebra, Catlab.Graphics, Catlab.Programs
+using CombinatorialSpaces.ExteriorCalculus
+using Catlab.Programs.DiagrammaticPrograms: NamedGraph
+using ..Simulations
+using ..AlgebraicPetri
+using LinearAlgebra
+using Unicode
+
+export pn2dec, expand_pres!, gen_functions
+
+i2sub = Dict(
+  '0'=>'₀', '1'=>'₁', '2'=>'₂', '3'=>'₃', '4'=>'₄', '5'=>'₅',
+  '6'=>'₆', '7'=>'₇', '8'=>'₈', '9'=>'₉', '-'=>'₋'
+)
+i2sup = Dict(
+  '0'=>'⁰', '1'=>'¹', '2'=>'²', '3'=>'³', '4'=>'⁴', '5'=>'⁵',
+  '6'=>'⁶', '7'=>'⁷', '8'=>'⁸', '9'=>'⁹', '-'=>'⁻'
+)
+
+function neg_term(graph, obs, homs, prs, val::Int64)
+  res = add_part!(graph, :V, vname=Symbol("$(gensym())"))
+  push!(obs, prs.syntax.Form0(prs[:X]))
+  add_part!(graph, :E, ename=nothing, src=val, tgt=res)
+  push!(homs, prs[Symbol("neg₀")])
+  return res
+end
+
+function scale_term(graph, obs, homs, prs, val::Int64, sc::Int64)
+  res = add_part!(graph, :V, vname="$(gensym())")
+  push!(obs, prs.syntax.Form0(prs[:X]))
+  add_part!(graph, :E, ename=nothing, src=val, tgt=res)
+  push!(homs, prs[Symbol("mult_$(sc)")])
+  return res
+end
+
+function exp_term(graph, obs, homs, prs, val::Int64, sc::Int64)
+  res = add_part!(graph, :V, vname=Symbol("$(gensym())"))
+  push!(obs, prs.syntax.Form0(prs[:X]))
+  add_part!(graph, :E, ename=nothing, src=val, tgt=res)
+  push!(homs, prs[Symbol("^$(sc)")])
+  return res
+end
+
+function rate_term(graph, obs, homs, prs, val::Int64, tr_name::Symbol, tgt::Int64)
+  add_part!(graph, :E, ename=nothing, src=val, tgt=tgt)
+  push!(homs, prs[Symbol("k_", tr_name)])
+  return tgt
+end
+
+function rate_term(graph, obs, homs, prs, val::Int64, tr_name::Symbol)
+  res = add_part!(graph, :V, vname=Symbol("$(gensym())"))
+  push!(obs, prs.syntax.Form0(prs[:X]))
+  rate_term(graph, obs, homs, prs, val, tr_name, res)
+end
+
+function sum_dec!(graph, obs, homs, prs, vals::Int64...)
+  bin_exp!(graph, obs, homs, prs, :sum₀, vals...)
+end
+
+function prod_dec!(graph, obs, homs, prs, vals::Int64...)
+  bin_exp!(graph, obs, homs, prs, :prod₀, vals...)
+end
+
+function bin_exp!(graph, obs, homs, prs, exp, vals::Int64...)
+  if length(vals) == 1
+    first(vals)
+  else
+    form0 = prs.syntax.Form0(prs[:X])
+    form0x0 = prs.syntax.otimes(form0, form0)
+    cur_val = first(vals)
+    bin_int = add_parts!(graph, :V, length(vals)-1,
+              vname=[Symbol("$(gensym())") for i in 1:(length(vals)-1)])
+    bin_res = add_parts!(graph, :V, length(vals)-1,
+              vname=[Symbol("$(gensym())") for i in 1:(length(vals)-1)])
+    append!(obs, fill(form0x0, length(vals)-1))
+    append!(obs, fill(form0, length(vals)-1))
+    for i in 1:(length(vals)-1)
+      add_parts!(graph, :E, 3,
+                ename =[nothing, nothing, nothing],
+                tgt=[vals[i+1], cur_val, bin_res[i]],
+                src=[bin_int[i], bin_int[i], bin_int[i]])
+      append!(homs, [prs[:proj¹_⁰⁰₀], prs[:proj²_⁰⁰₀], prs[exp]])
+      cur_val = bin_res[i]
+    end
+    cur_val
+  end
+end
+
+function pn2dec(prs, pn::LabelledReactionNet)
+  synt = prs.syntax
+
+  # Initial state variables
+  graph = NamedGraph{Symbol,Union{Symbol,Nothing}}()
+  svars = add_parts!(graph, :V, ns(pn), vname=snames(pn))
+  tvars = add_parts!(graph, :V, nt(pn), vname=tnames(pn))
+  obs  = Vector{Any}(fill(synt.Form0(prs[:X]), ns(pn) + nt(pn))) #"($(join(vcat(snames(pn), tnames(pn)), ", ")))::Form0{X}"
+  homs = Vector{Any}()
+  map(1:nt(pn)) do t
+    inputs = pn[incident(pn, t, :it), :is]
+    res = prod_dec!(graph, obs, homs, prs, svars[inputs]...)
+    rate_term(graph, obs, homs, prs, res, tname(pn, t), tvars[t])
+  end
+
+  res_s = map(1:ns(pn)) do s
+    inps = tvars[pn[incident(pn, s, :os), :ot]]
+    otps = tvars[pn[incident(pn, s, :is), :it]]
+    otp_scaled = [neg_term(graph, obs, homs, prs, o) for o in otps]
+    if isempty(vcat(inps, otp_scaled))
+      res = add_part!(graph, :V, vname=Symbol("$(gensym())"))
+      push!(obs, prs.syntax.Form0(prs[:X]))
+      res
+    else
+      sum_dec!(graph, obs, homs, prs, vcat(inps, otp_scaled)...)
+    end
+  end
+
+  set_subparts!(graph, res_s,
+    vname=[length("$name") > 1 ?
+            Symbol("∂ₜ", "$name") : Symbol(Unicode.normalize("$name"* "̇"))
+            for name in snames(pn)])
+  @show incident(graph, :Ṙ, :vname)
+  FinFunctor(obs, homs, FinCat(graph), FinCat(prs))
+end
+
+function expand_pres!(pres, pn::LabelledReactionNet)
+  synt = pres.syntax
+  form0 = synt.Form0(pres[:X])
+  form0x0 = synt.otimes(form0, form0)
+  gens = Dict(:neg₀ => synt.Hom(:neg₀, form0, form0),
+              :sum₀ => synt.Hom(:sum₀, form0x0, form0),
+              :prod₀ => synt.Hom(:prod₀, form0x0, form0),
+              :proj¹_⁰⁰₀ => synt.Hom(:proj¹_⁰⁰₀, form0x0, form0),
+              :proj²_⁰⁰₀ => synt.Hom(:proj²_⁰⁰₀, form0x0, form0))
+  for t in tnames(pn)
+    gens[t] = synt.Hom(Symbol("k_$t"), form0, form0)
+  end
+
+  for (k,v) in gens
+    if !has_generator(pres, k)
+      add_generator!(pres, v)
+    end
+  end
+end
+
+function gen_functions(pn::LabelledReactionNet, s)
+  funcs = Dict{Symbol, Any}()
+  funcs[:sum₀] = Dict(:operator => (s,a,b) -> (s .= a .+ b), :type => InPlaceFunc())
+  funcs[:prod₀] = Dict(:operator => (s,a,b) -> (s .= a .* b), :type => InPlaceFunc())
+  funcs[:neg₀] = Dict(:operator => (s,a) -> (s .= -1 * a), :type => InPlaceFunc())
+  for t in 1:nt(pn)
+    funcs[Symbol("k_", tname(pn, t))] = Dict(:operator => rate(pn, t) * I(nv(s)), :type => MatrixFunc())
+  end
+  funcs
+end
+
+end

--- a/src/PetriNets.jl
+++ b/src/PetriNets.jl
@@ -81,7 +81,7 @@ function bin_exp!(graph, obs, homs, prs, exp, vals::Int64...)
                 ename =[nothing, nothing, nothing],
                 tgt=[vals[i+1], cur_val, bin_res[i]],
                 src=[bin_int[i], bin_int[i], bin_int[i]])
-      append!(homs, [prs[:proj¹_⁰⁰₀], prs[:proj²_⁰⁰₀], prs[exp]])
+      append!(homs, [prs[:proj₁_⁰⁰₀], prs[:proj₂_⁰⁰₀], prs[exp]])
       cur_val = bin_res[i]
     end
     cur_val
@@ -118,9 +118,8 @@ function pn2dec(prs, pn::LabelledReactionNet)
 
   set_subparts!(graph, res_s,
     vname=[length("$name") > 1 ?
-            Symbol("∂ₜ", "$name") : Symbol(Unicode.normalize("$name"* "̇"))
+            Symbol("∂ₜ", "$name") : Symbol(Unicode.normalize("$name"* '̇'))
             for name in snames(pn)])
-  @show incident(graph, :Ṙ, :vname)
   FinFunctor(obs, homs, FinCat(graph), FinCat(prs))
 end
 
@@ -131,8 +130,8 @@ function expand_pres!(pres, pn::LabelledReactionNet)
   gens = Dict(:neg₀ => synt.Hom(:neg₀, form0, form0),
               :sum₀ => synt.Hom(:sum₀, form0x0, form0),
               :prod₀ => synt.Hom(:prod₀, form0x0, form0),
-              :proj¹_⁰⁰₀ => synt.Hom(:proj¹_⁰⁰₀, form0x0, form0),
-              :proj²_⁰⁰₀ => synt.Hom(:proj²_⁰⁰₀, form0x0, form0))
+              :proj₁_⁰⁰₀ => synt.Hom(:proj₁_⁰⁰₀, form0x0, form0),
+              :proj₂_⁰⁰₀ => synt.Hom(:proj₂_⁰⁰₀, form0x0, form0))
   for t in tnames(pn)
     gens[t] = synt.Hom(Symbol("k_$t"), form0, form0)
   end

--- a/test/Decapodes.jl
+++ b/test/Decapodes.jl
@@ -44,7 +44,7 @@ module DecapodesTest
 
 	composed_diff = oapply(compose_diff, [OpenDiagram(Diffusion, [:C, :Ċ]), OpenDiagram(Dynamics, [:C, :Ċ])]);
 
-	res = diag2dwd(composed_diff.functor, arg_order = [:C])
+  res = diag2dwd(composed_diff.functor, in_vars = [:C], out_vars = [:Ċ])
 
 	s = EmbeddedDeltaSet2D{Bool, Point{3,Float64}}()
 	points = [(0,0,0),(0,0,1),(0,1,0),(0,1,1)]

--- a/test/Examples.jl
+++ b/test/Examples.jl
@@ -1,0 +1,18 @@
+module DecapodesTest
+
+  using Catlab
+	using Catlab.Present
+  using Catlab.Programs
+	using CombinatorialSpaces
+  using Catlab.WiringDiagrams
+	using CombinatorialSpaces.ExteriorCalculus
+  using Test
+
+	using Decapodes.Examples
+
+  rules = gen_dec_rules()
+  for v in values(rules)
+    @test v isa WiringDiagram
+  end
+
+end

--- a/test/Examples.jl
+++ b/test/Examples.jl
@@ -1,4 +1,4 @@
-module DecapodesTest
+module ExamplesTest
 
   using Catlab
 	using Catlab.Present

--- a/test/PetriNets.jl
+++ b/test/PetriNets.jl
@@ -1,0 +1,105 @@
+module PetriNetsTest
+
+  using Catlab
+	using Catlab.Present
+  using Catlab.Programs
+	using CombinatorialSpaces
+	using CombinatorialSpaces.ExteriorCalculus
+	using GeometryBasics
+  using LinearAlgebra
+  using AlgebraicPetri
+  using Test
+
+	using Decapodes.Simulations
+	using Decapodes.Diagrams
+	using Decapodes.Schedules
+  using Decapodes.Examples
+	using Decapodes.OpenDiagrams
+  using Decapodes.PetriNets
+  using Random
+	@present DiffusionSpace2D(FreeExtCalc2D) begin
+	  X::Space
+	  k::Hom(Form1(X), Form1(X)) # diffusivity of space, usually constant (scalar multiplication)
+	  proj₁_⁰⁰₀::Hom(Form0(X) ⊗ Form0(X), Form0(X))
+	  proj₂_⁰⁰₀::Hom(Form0(X) ⊗ Form0(X), Form0(X))
+	  sum₀::Hom(Form0(X) ⊗ Form0(X), Form0(X))
+	  prod₀::Hom(Form0(X) ⊗ Form0(X), Form0(X))
+	end
+	
+	SIRD = LabelledReactionNet{Float64, Float64}([:S=>0.0, :I=>0.0, :R=>0.0, :D=>0.0],
+	                                             (:inf=>0.01)=>((:S,:I)=>(:I,:I)),
+	                                             (:rec=>0.001)=>(:I=>:R),
+	                                             (:death=>0.01)=>(:I=>:D))
+
+  expand_pres!(DiffusionSpace2D, SIRD)
+
+	Diffusion = @decapode DiffusionSpace2D begin
+	  (C, Ċ)::Form0{X}
+
+	  Ċ == ⋆₀⁻¹{X}(dual_d₁{X}(⋆₁{X}(k(d₀{X}(C)))))
+	end
+
+	Superposition = @decapode DiffusionSpace2D begin
+	  (C, Ċ₁, Ċ₂)::Form0{X}
+
+	  ∂ₜ{Form0{X}}(C) == Ċ₁ + Ċ₂ 
+	end
+
+
+  sird_dec = pn2dec(DiffusionSpace2D, SIRD)
+
+	compose_epi = @relation (S,I,R) begin
+	  epi(S,I,R, D, Ṡ₁,İ₁, Ṙ₁, Ḋ₁)
+	  diff(S, Ṡ₂)
+	  diff(I, İ₂)
+	  diff(R, Ṙ₂)
+	  diff(D, Ḋ₂)
+	  superpos(Ṡ₁,Ṡ₂, S)
+	  superpos(İ₁,İ₂, I)
+	  superpos(Ṙ₁,Ṙ₂, R)
+	  superpos(Ḋ₁,Ḋ₂, D)
+	end
+	
+
+	composed_epi = oapply(compose_epi, vcat(
+    [OpenDiagram(sird_dec, [:S, :I, :R, :D, :Ṡ, :İ, :Ṙ, :Ḋ])],
+    [OpenDiagram(Diffusion, [:C, :Ċ]) for i in 1:ns(SIRD)],
+    [OpenDiagram(Superposition, [:Ċ₁, :Ċ₂, :C]) for i in 1:ns(SIRD)]
+    ));
+  
+  res = diag2dwd(composed_epi.functor, in_vars = [:S, :I, :R, :D])
+
+	s = EmbeddedDeltaSet2D{Bool, Point{3,Float64}}()
+	points = [(0,0,0),(0,0,1),(0,1,0),(0,1,1)]
+
+	add_vertices!(s, 4, point=points)
+	glue_sorted_triangle!(s, 1,2,3)
+	glue_sorted_triangle!(s, 2,3,4)
+
+	sd = dual(s);
+
+	funcs = sym2func(sd)
+	funcs[:k] = Dict(:operator => 1.0 * I(ne(sd)), :type => MatrixFunc())
+  merge!(funcs, gen_functions(SIRD, s))
+
+	Examples.contract_matrices!(res, funcs)
+
+  sim, _ = gen_sim(res, funcs, sd);
+
+  Random.seed!(42)
+  u  = rand(nv(s)*4)
+  du = zeros(Float64,nv(s)*4)
+
+	tempu = copy(u)
+  dt = 0.001
+  for i in 10000
+    sim(du, tempu, [],0)
+    tempu .+= du
+    # Check that population is conserved
+  end
+  @test all(tempu .!= u)
+  
+  mass_diff = sum(vcat([⋆(Val{0}, sd)*(tempu[(1:nv(s)) .+ (i-1) * nv(s)]) for i in 1:4]...)) - 
+              sum(vcat([⋆(Val{0}, sd)*(u[(1:nv(s)) .+ (i-1) * nv(s)]) for i in 1:4]...))
+  @test mass_diff < 1e-6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,11 @@ using Test
 @testset "Decapodes" begin
   include("Decapodes.jl")
 end
+
+@testset "PetriNets" begin
+  include("PetriNets.jl")
+end
+
+@testset "Examples" begin
+  include("Examples.jl")
+end


### PR DESCRIPTION
This PR adds interop tooling with AlgebraicPetri by converting a LabelledReactionNet into a Decapode under the law of mass-action.