### PR TITLE
BUG: Fix Documenter Failing with Local Assets

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,7 @@ end
 #end
 
 @info "Building Documenter.jl docs"
+@info pwd()
 makedocs(
   modules   = [Decapodes],
   format    = Documenter.HTML(

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -118,9 +118,9 @@ using CairoMakie
 using JSON
 
 @show pwd() #hide
-periodic_mesh = read_json_acset(EmbeddedDeltaDualComplex2D{Bool, Float64, Point3{Float64}}, "../../assets/meshes/periodic_mesh.json")
-plot_mesh = read_json_acset(EmbeddedDeltaSet2D{Bool, Point3{Float64}}, "../../assets/meshes/plot_mesh.json")
-point_map = JSON.parsefile("../../assets/meshes/point_map.json")
+periodic_mesh = read_json_acset(EmbeddedDeltaDualComplex2D{Bool, Float64, Point3{Float64}}, "assets/meshes/periodic_mesh.json")
+plot_mesh = read_json_acset(EmbeddedDeltaSet2D{Bool, Point3{Float64}}, "assets/meshes/plot_mesh.json")
+point_map = JSON.parsefile("assets/meshes/point_map.json")
 
 fig, ax, ob = wireframe(plot_mesh)
 ax.aspect = AxisAspect(3.0)


### PR DESCRIPTION
This PR resolves the bug of local file dependencies not being discoverable during the Documenter build process