### PR TITLE
Mesh artifacts and mesh loading

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,6 @@
+[all_meshes]
+git-tree-sha1 = "9482e8911a0f12c1be16910a2fc61486eb391b87"
+
+    [[all_meshes.download]]
+    sha256 = "79f180d7b2d880e1697c669355689e711a1dcacc76bc77518794288e1c80c978"
+    url = "https://raw.githubusercontent.com/AlgebraicJulia/DecapodesMeshes.jl/main/meshes/all_meshes.tar.gz"

--- a/src/Decapodes2/meshes.jl
+++ b/src/Decapodes2/meshes.jl
@@ -1,0 +1,41 @@
+using Artifacts
+using CombinatorialSpaces
+using FileIO
+
+abstract type AbstractMeshKey end
+
+struct UnitIcosphere   <: AbstractMeshKey end
+struct ThermoIcosphere <: AbstractMeshKey end
+struct UnitUVSphere    <: AbstractMeshKey end
+struct ThermoUVSphere  <: AbstractMeshKey end
+
+#loadmesh(meshkey::AbstractMeshKey)::EmbeddedDeltaSet2D
+
+function loadmesh_helper(obj_file_name)
+  all_meshes = artifact"all_meshes"
+  mesh_obj = FileIO.load(File{format"OBJ"}(joinpath(all_meshes, obj_file_name)))
+  mesh = EmbeddedDeltaSet2D(mesh_obj)
+end
+
+#function loadmesh(meshkey::UnitIcosphere)::EmbeddedDeltaSet2D
+#  all_meshes = artifact"all_meshes"
+#  this_mesh = "unit_icosphere.obj"
+#  mesh_obj = FileIO.load(File{format"OBJ"}(joinpath(all_meshes, this_mesh)))
+#  mesh = EmbeddedDeltaSet2D(mesh_obj)
+#end
+function loadmesh(meshkey::UnitIcosphere)::EmbeddedDeltaSet2D
+  loadmesh_helper("unit_icosphere.obj")
+end
+
+function loadmesh(meshkey::ThermoIcosphere)::EmbeddedDeltaSet2D
+  loadmesh_helper("thermo_icosphere.obj")
+end
+
+function loadmesh(meshkey::UnitUVSphere)::EmbeddedDeltaSet2D
+  loadmesh_helper("unit_tie_gcm.obj")
+end
+
+function loadmesh(meshkey::ThermoUVSphere)::EmbeddedDeltaSet2D
+  loadmesh_helper("thermo_tie_gcm.obj")
+end
+

--- a/src/Decapodes2/meshes.jl
+++ b/src/Decapodes2/meshes.jl
@@ -11,11 +11,8 @@ struct ThermoUVSphere  <: AbstractMeshKey end
 
 #loadmesh(meshkey::AbstractMeshKey)::EmbeddedDeltaSet2D
 
-function loadmesh_helper(obj_file_name)
-  all_meshes = artifact"all_meshes"
-  mesh_obj = FileIO.load(File{format"OBJ"}(joinpath(all_meshes, obj_file_name)))
-  mesh = EmbeddedDeltaSet2D(mesh_obj)
-end
+loadmesh_helper(obj_file_name) = EmbeddedDeltaSet2D(
+  joinpath(artifact"all_meshes", obj_file_name))
 
 #function loadmesh(meshkey::UnitIcosphere)::EmbeddedDeltaSet2D
 #  all_meshes = artifact"all_meshes"

--- a/src/Decapodes2/meshes.jl
+++ b/src/Decapodes2/meshes.jl
@@ -2,6 +2,8 @@ using Artifacts
 using CombinatorialSpaces
 using FileIO
 
+export AbstractMeshKey, loadmesh, UnitIcosphere, ThermoIcosphere, UnitUVSphere, ThermoUVSphere
+
 abstract type AbstractMeshKey end
 
 struct UnitIcosphere   <: AbstractMeshKey end

--- a/test/Decapodes2/meshes.jl
+++ b/test/Decapodes2/meshes.jl
@@ -1,0 +1,66 @@
+using Catlab, Catlab.CategoricalAlgebra
+using CombinatorialSpaces
+using Test
+
+# TODO: Remove this line when we can do using Decapodes.
+include("../../src/Decapodes2/meshes.jl")
+
+# TODO: Move the testset macro to runtests.jl.
+@testset "Meshes" begin
+
+# Unit Icosphere
+unit_icosphere = loadmesh(UnitIcosphere())
+@test nv(unit_icosphere) == 2562
+@test ne(unit_icosphere) == 7680
+@test nparts(unit_icosphere, :Tri) == 5120
+
+# Icosphere at minimum altitude of thermosphere
+thermo_icosphere = loadmesh(ThermoIcosphere())
+@test nv(thermo_icosphere) == 2562
+@test ne(thermo_icosphere) == 7680
+@test nparts(thermo_icosphere, :Tri) == 5120
+
+# Unit UV sphere (TIE GCM grid)
+unit_uvsphere = loadmesh(UnitUVSphere())
+@test nv(unit_uvsphere) == 2522
+@test ne(unit_uvsphere) == 7560
+@test nparts(unit_uvsphere, :Tri) == 5040
+
+# Icosphere at minimum altitude of thermosphere
+thermo_uvsphere = loadmesh(ThermoUVSphere())
+@test nv(thermo_uvsphere) == 2522
+@test ne(thermo_uvsphere) == 7560
+@test nparts(thermo_uvsphere, :Tri) == 5040
+
+
+magnitude = (sqrt ∘ (x -> foldl(+, x*x)))
+
+# The definition of a discretization of a sphere of unspecified radius.
+ρ′ = magnitude(unit_icosphere[:point][begin])
+@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ′))
+# The definition of a discretization of a sphere of radius ρ.
+ρ = 1
+@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ))
+
+# The definition of a discretization of a sphere of unspecified radius.
+ρ′ = magnitude(thermo_icosphere[:point][begin])
+@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ′))
+ρ = 6371+90
+# The definition of a discretization of a sphere of radius ρ.
+@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ))
+
+# The definition of a discretization of a sphere of unspecified radius.
+ρ′ = magnitude(unit_uvsphere[:point][begin])
+@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ′))
+# The definition of a discretization of a sphere of radius ρ.
+ρ = 1
+@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ))
+
+# The definition of a discretization of a sphere of unspecified radius.
+ρ′ = magnitude(thermo_uvsphere[:point][begin])
+@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ′))
+# The definition of a discretization of a sphere of radius ρ.
+ρ = 6371+90
+@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ))
+
+end


### PR DESCRIPTION
Closes #58 

I have implemented mesh loading based on singleton types, with accompanying tests.

However, `export`ing a `loadmesh(meshkey::AbstractMeshKey)` is a little confusing.

I believe progress may go quicker on this issue if discussed in this PR, rather than me poring through the Julia manual alone.