### PR TITLE
Add icospheres of many subdivisions

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -9,5 +9,5 @@ git-tree-sha1 = "9482e8911a0f12c1be16910a2fc61486eb391b87"
 git-tree-sha1 = "7db4629f78161cdd08310b6f37ade7d50604f55d"
 
     [[all_meshes2.download]]
-    sha256 = "46d730bfa6cd6cbcb16babd4c56ae64c5491c0328152733c798f862e45381b28"
+    sha256 = "d1f6a4e3bf9134d95a38cd09e4e141098bf8f2543eb6bea041db330f1ced6a73"
     url = "https://raw.githubusercontent.com/AlgebraicJulia/DecapodesMeshes.jl/main/meshes/all_meshes2.tar.gz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,3 +4,10 @@ git-tree-sha1 = "9482e8911a0f12c1be16910a2fc61486eb391b87"
     [[all_meshes.download]]
     sha256 = "79f180d7b2d880e1697c669355689e711a1dcacc76bc77518794288e1c80c978"
     url = "https://raw.githubusercontent.com/AlgebraicJulia/DecapodesMeshes.jl/main/meshes/all_meshes.tar.gz"
+
+[all_meshes2]
+git-tree-sha1 = "7db4629f78161cdd08310b6f37ade7d50604f55d"
+
+    [[all_meshes2.download]]
+    sha256 = "46d730bfa6cd6cbcb16babd4c56ae64c5491c0328152733c798f862e45381b28"
+    url = "https://raw.githubusercontent.com/AlgebraicJulia/DecapodesMeshes.jl/main/meshes/all_meshes2.tar.gz"

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -19,8 +19,9 @@ export normalize_unicode, DerivOp, append_dot,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,
-  AbstractMeshKey, loadmesh, UnitIcosphere, ThermoIcosphere, UnitUVSphere, ThermoUVSphere,
+  AbstractMeshKey, loadmesh, UnitIcosphere1, UnitIcosphere2, UnitIcosphere3, UnitIcosphere4, UnitIcosphere5, 
   Open, OpenSummationDecapodeOb, OpenSummationDecapode, unique_by, unique_by!, oapply
+  #AbstractMeshKey, loadmesh, UnitIcosphere, ThermoIcosphere, UnitUVSphere, ThermoUVSphere,
 
 normalize_unicode(s::String) = Unicode.normalize(s, compose=true, stable=true, chartransform=Unicode.julia_chartransform)
 normalize_unicode(s::Symbol)  = Symbol(normalize_unicode(String(s)))

--- a/src/Decapodes2/meshes.jl
+++ b/src/Decapodes2/meshes.jl
@@ -6,15 +6,22 @@ using FileIO
 
 abstract type AbstractMeshKey end
 
-struct UnitIcosphere   <: AbstractMeshKey end
-struct ThermoIcosphere <: AbstractMeshKey end
-struct UnitUVSphere    <: AbstractMeshKey end
-struct ThermoUVSphere  <: AbstractMeshKey end
+#struct UnitIcosphere   <: AbstractMeshKey end
+#struct ThermoIcosphere <: AbstractMeshKey end
+#struct UnitUVSphere    <: AbstractMeshKey end
+#struct ThermoUVSphere  <: AbstractMeshKey end
+
+struct UnitIcosphere1 <: AbstractMeshKey end
+struct UnitIcosphere2 <: AbstractMeshKey end
+struct UnitIcosphere3 <: AbstractMeshKey end
+struct UnitIcosphere4 <: AbstractMeshKey end
+struct UnitIcosphere5 <: AbstractMeshKey end
+
 
 #loadmesh(meshkey::AbstractMeshKey)::EmbeddedDeltaSet2D
 
 loadmesh_helper(obj_file_name) = EmbeddedDeltaSet2D(
-  joinpath(artifact"all_meshes", obj_file_name))
+  joinpath(artifact"all_meshes2", obj_file_name))
 
 #function loadmesh(meshkey::UnitIcosphere)::EmbeddedDeltaSet2D
 #  all_meshes = artifact"all_meshes"
@@ -22,19 +29,24 @@ loadmesh_helper(obj_file_name) = EmbeddedDeltaSet2D(
 #  mesh_obj = FileIO.load(File{format"OBJ"}(joinpath(all_meshes, this_mesh)))
 #  mesh = EmbeddedDeltaSet2D(mesh_obj)
 #end
-function loadmesh(meshkey::UnitIcosphere)::EmbeddedDeltaSet2D
-  loadmesh_helper("unit_icosphere.obj")
+
+function loadmesh(meshkey::UnitIcosphere1)::EmbeddedDeltaSet2D
+  loadmesh_helper("UnitIcosphere1.obj")
 end
 
-function loadmesh(meshkey::ThermoIcosphere)::EmbeddedDeltaSet2D
-  loadmesh_helper("thermo_icosphere.obj")
+function loadmesh(meshkey::UnitIcosphere2)::EmbeddedDeltaSet2D
+  loadmesh_helper("UnitIcosphere2.obj")
 end
 
-function loadmesh(meshkey::UnitUVSphere)::EmbeddedDeltaSet2D
-  loadmesh_helper("unit_tie_gcm.obj")
+function loadmesh(meshkey::UnitIcosphere3)::EmbeddedDeltaSet2D
+  loadmesh_helper("UnitIcosphere3.obj")
 end
 
-function loadmesh(meshkey::ThermoUVSphere)::EmbeddedDeltaSet2D
-  loadmesh_helper("thermo_tie_gcm.obj")
+function loadmesh(meshkey::UnitIcosphere4)::EmbeddedDeltaSet2D
+  loadmesh_helper("UnitIcosphere4.obj")
+end
+
+function loadmesh(meshkey::UnitIcosphere5)::EmbeddedDeltaSet2D
+  loadmesh_helper("UnitIcosphere5.obj")
 end
 

--- a/src/Decapodes2/meshes.jl
+++ b/src/Decapodes2/meshes.jl
@@ -6,47 +6,21 @@ using FileIO
 
 abstract type AbstractMeshKey end
 
-#struct UnitIcosphere   <: AbstractMeshKey end
-#struct ThermoIcosphere <: AbstractMeshKey end
-#struct UnitUVSphere    <: AbstractMeshKey end
-#struct ThermoUVSphere  <: AbstractMeshKey end
+struct Icosphere{N, R} <: AbstractMeshKey
+  n::N
+  r::R
+end
 
-struct UnitIcosphere1 <: AbstractMeshKey end
-struct UnitIcosphere2 <: AbstractMeshKey end
-struct UnitIcosphere3 <: AbstractMeshKey end
-struct UnitIcosphere4 <: AbstractMeshKey end
-struct UnitIcosphere5 <: AbstractMeshKey end
+Icosphere(n) = Icosphere(n, 1.0)
 
+function loadmesh(s::Icosphere)
+  1 <= s.n <= 5 || error("The only icosphere divisions supported are 1-5")
+  m = loadmesh_helper("UnitIcosphere$(s.n).obj")
+  m[:point] .*= s.r
+  return m
+end
 
 #loadmesh(meshkey::AbstractMeshKey)::EmbeddedDeltaSet2D
 
 loadmesh_helper(obj_file_name) = EmbeddedDeltaSet2D(
   joinpath(artifact"all_meshes2", obj_file_name))
-
-#function loadmesh(meshkey::UnitIcosphere)::EmbeddedDeltaSet2D
-#  all_meshes = artifact"all_meshes"
-#  this_mesh = "unit_icosphere.obj"
-#  mesh_obj = FileIO.load(File{format"OBJ"}(joinpath(all_meshes, this_mesh)))
-#  mesh = EmbeddedDeltaSet2D(mesh_obj)
-#end
-
-function loadmesh(meshkey::UnitIcosphere1)::EmbeddedDeltaSet2D
-  loadmesh_helper("UnitIcosphere1.obj")
-end
-
-function loadmesh(meshkey::UnitIcosphere2)::EmbeddedDeltaSet2D
-  loadmesh_helper("UnitIcosphere2.obj")
-end
-
-function loadmesh(meshkey::UnitIcosphere3)::EmbeddedDeltaSet2D
-  loadmesh_helper("UnitIcosphere3.obj")
-end
-
-function loadmesh(meshkey::UnitIcosphere4)::EmbeddedDeltaSet2D
-  loadmesh_helper("UnitIcosphere4.obj")
-end
-
-function loadmesh(meshkey::UnitIcosphere5)::EmbeddedDeltaSet2D
-  loadmesh_helper("UnitIcosphere5.obj")
-end
-

--- a/test/Decapodes2/meshes.jl
+++ b/test/Decapodes2/meshes.jl
@@ -8,59 +8,49 @@ include("../../src/Decapodes2/meshes.jl")
 # TODO: Move the testset macro to runtests.jl.
 @testset "Meshes" begin
 
-# Unit Icosphere
-#unit_icosphere = loadmesh(UnitIcosphere())
-#@test nv(unit_icosphere) == 2562
-#@test ne(unit_icosphere) == 7680
-#@test nparts(unit_icosphere, :Tri) == 5120
-#
-## Icosphere at minimum altitude of thermosphere
-#thermo_icosphere = loadmesh(ThermoIcosphere())
-#@test nv(thermo_icosphere) == 2562
-#@test ne(thermo_icosphere) == 7680
-#@test nparts(thermo_icosphere, :Tri) == 5120
-#
-## Unit UV sphere (TIE GCM grid)
-#unit_uvsphere = loadmesh(UnitUVSphere())
-#@test nv(unit_uvsphere) == 2522
-#@test ne(unit_uvsphere) == 7560
-#@test nparts(unit_uvsphere, :Tri) == 5040
-#
-## Icosphere at minimum altitude of thermosphere
-#thermo_uvsphere = loadmesh(ThermoUVSphere())
-#@test nv(thermo_uvsphere) == 2522
-#@test ne(thermo_uvsphere) == 7560
-#@test nparts(thermo_uvsphere, :Tri) == 5040
-#
-#
-#magnitude = (sqrt ∘ (x -> foldl(+, x*x)))
-#
-## The definition of a discretization of a sphere of unspecified radius.
-#ρ′ = magnitude(unit_icosphere[:point][begin])
-#@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ′))
-## The definition of a discretization of a sphere of radius ρ.
-#ρ = 1
-#@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ))
-#
-## The definition of a discretization of a sphere of unspecified radius.
-#ρ′ = magnitude(thermo_icosphere[:point][begin])
-#@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ′))
-#ρ = 6371+90
-## The definition of a discretization of a sphere of radius ρ.
-#@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ))
-#
-## The definition of a discretization of a sphere of unspecified radius.
-#ρ′ = magnitude(unit_uvsphere[:point][begin])
-#@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ′))
-## The definition of a discretization of a sphere of radius ρ.
-#ρ = 1
-#@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ))
-#
-## The definition of a discretization of a sphere of unspecified radius.
-#ρ′ = magnitude(thermo_uvsphere[:point][begin])
-#@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ′))
-## The definition of a discretization of a sphere of radius ρ.
-#ρ = 6371+90
-#@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ))
+magnitude = (sqrt ∘ (x -> foldl(+, x*x)))
+unit_radius = 1
+
+# Unit Icospheres are of the proper dimensions, and are spheres.
+unit_icosphere1 = loadmesh(UnitIcosphere1())
+@test nv(unit_icosphere1) == 12
+@test ne(unit_icosphere1) == 30
+@test nparts(unit_icosphere1, :Tri) == 20
+ρ = magnitude(unit_icosphere1[:point][begin])
+@test all(isapprox.(magnitude.(unit_icosphere1[:point]), ρ))
+@test ρ == unit_radius
+
+unit_icosphere2 = loadmesh(UnitIcosphere2())
+@test nv(unit_icosphere2) == 42
+@test ne(unit_icosphere2) == 120
+@test nparts(unit_icosphere2, :Tri) == 80
+ρ = magnitude(unit_icosphere2[:point][begin])
+@test all(isapprox.(magnitude.(unit_icosphere2[:point]), ρ))
+@test ρ == unit_radius
+
+unit_icosphere3 = loadmesh(UnitIcosphere3())
+@test nv(unit_icosphere3) == 162
+@test ne(unit_icosphere3) == 480
+@test nparts(unit_icosphere3, :Tri) == 320
+ρ = magnitude(unit_icosphere3[:point][begin])
+@test all(isapprox.(magnitude.(unit_icosphere3[:point]), ρ))
+@test ρ == unit_radius
+
+unit_icosphere4 = loadmesh(UnitIcosphere4())
+@test nv(unit_icosphere4) == 642
+@test ne(unit_icosphere4) == 1920
+@test nparts(unit_icosphere4, :Tri) == 1280
+ρ = magnitude(unit_icosphere4[:point][begin])
+@test all(isapprox.(magnitude.(unit_icosphere4[:point]), ρ))
+@test ρ == unit_radius
+
+unit_icosphere5 = loadmesh(UnitIcosphere5())
+@test nv(unit_icosphere5) == 2562
+@test ne(unit_icosphere5) == 7680
+@test nparts(unit_icosphere5, :Tri) == 5120
+ρ = magnitude(unit_icosphere5[:point][begin])
+@test all(isapprox.(magnitude.(unit_icosphere5[:point]), ρ))
+@test ρ == unit_radius
 
 end
+

--- a/test/Decapodes2/meshes.jl
+++ b/test/Decapodes2/meshes.jl
@@ -10,47 +10,67 @@ include("../../src/Decapodes2/meshes.jl")
 
 magnitude = (sqrt ∘ (x -> foldl(+, x*x)))
 unit_radius = 1
+euler_characteristic(p) = nv(p) - ne(p) + nparts(p, :Tri)
 
-# Unit Icospheres are of the proper dimensions, and are spheres.
-unit_icosphere1 = loadmesh(UnitIcosphere1())
+# Unit Icospheres are of the proper dimensions, are spheres, and have the right
+# Euler characteristic.
+unit_icosphere1 = loadmesh(Icosphere(1))
 @test nv(unit_icosphere1) == 12
 @test ne(unit_icosphere1) == 30
 @test nparts(unit_icosphere1, :Tri) == 20
 ρ = magnitude(unit_icosphere1[:point][begin])
 @test all(isapprox.(magnitude.(unit_icosphere1[:point]), ρ))
 @test ρ == unit_radius
+@test euler_characteristic(unit_icosphere1) == 2
 
-unit_icosphere2 = loadmesh(UnitIcosphere2())
+unit_icosphere2 = loadmesh(Icosphere(2))
 @test nv(unit_icosphere2) == 42
 @test ne(unit_icosphere2) == 120
 @test nparts(unit_icosphere2, :Tri) == 80
 ρ = magnitude(unit_icosphere2[:point][begin])
 @test all(isapprox.(magnitude.(unit_icosphere2[:point]), ρ))
 @test ρ == unit_radius
+@test euler_characteristic(unit_icosphere2) == 2
 
-unit_icosphere3 = loadmesh(UnitIcosphere3())
+unit_icosphere3 = loadmesh(Icosphere(3))
 @test nv(unit_icosphere3) == 162
 @test ne(unit_icosphere3) == 480
 @test nparts(unit_icosphere3, :Tri) == 320
 ρ = magnitude(unit_icosphere3[:point][begin])
 @test all(isapprox.(magnitude.(unit_icosphere3[:point]), ρ))
 @test ρ == unit_radius
+@test euler_characteristic(unit_icosphere3) == 2
 
-unit_icosphere4 = loadmesh(UnitIcosphere4())
+unit_icosphere4 = loadmesh(Icosphere(4))
 @test nv(unit_icosphere4) == 642
 @test ne(unit_icosphere4) == 1920
 @test nparts(unit_icosphere4, :Tri) == 1280
 ρ = magnitude(unit_icosphere4[:point][begin])
 @test all(isapprox.(magnitude.(unit_icosphere4[:point]), ρ))
 @test ρ == unit_radius
+@test euler_characteristic(unit_icosphere4) == 2
 
-unit_icosphere5 = loadmesh(UnitIcosphere5())
+unit_icosphere5 = loadmesh(Icosphere(5))
 @test nv(unit_icosphere5) == 2562
 @test ne(unit_icosphere5) == 7680
 @test nparts(unit_icosphere5, :Tri) == 5120
 ρ = magnitude(unit_icosphere5[:point][begin])
 @test all(isapprox.(magnitude.(unit_icosphere5[:point]), ρ))
 @test ρ == unit_radius
+@test euler_characteristic(unit_icosphere5) == 2
+
+
+# Testing the radius parameter.
+thermosphere_radius = 6371 + 90
+
+thermo_icosphere5 = loadmesh(Icosphere(5, thermosphere_radius))
+@test nv(thermo_icosphere5) == 2562
+@test ne(thermo_icosphere5) == 7680
+@test nparts(thermo_icosphere5, :Tri) == 5120
+ρ = magnitude(thermo_icosphere5[:point][begin])
+@test all(isapprox.(magnitude.(thermo_icosphere5[:point]), ρ))
+@test ρ == thermosphere_radius
+@test euler_characteristic(thermo_icosphere5) == 2
+
 
 end
-

--- a/test/Decapodes2/meshes.jl
+++ b/test/Decapodes2/meshes.jl
@@ -9,58 +9,58 @@ include("../../src/Decapodes2/meshes.jl")
 @testset "Meshes" begin
 
 # Unit Icosphere
-unit_icosphere = loadmesh(UnitIcosphere())
-@test nv(unit_icosphere) == 2562
-@test ne(unit_icosphere) == 7680
-@test nparts(unit_icosphere, :Tri) == 5120
-
-# Icosphere at minimum altitude of thermosphere
-thermo_icosphere = loadmesh(ThermoIcosphere())
-@test nv(thermo_icosphere) == 2562
-@test ne(thermo_icosphere) == 7680
-@test nparts(thermo_icosphere, :Tri) == 5120
-
-# Unit UV sphere (TIE GCM grid)
-unit_uvsphere = loadmesh(UnitUVSphere())
-@test nv(unit_uvsphere) == 2522
-@test ne(unit_uvsphere) == 7560
-@test nparts(unit_uvsphere, :Tri) == 5040
-
-# Icosphere at minimum altitude of thermosphere
-thermo_uvsphere = loadmesh(ThermoUVSphere())
-@test nv(thermo_uvsphere) == 2522
-@test ne(thermo_uvsphere) == 7560
-@test nparts(thermo_uvsphere, :Tri) == 5040
-
-
-magnitude = (sqrt ∘ (x -> foldl(+, x*x)))
-
-# The definition of a discretization of a sphere of unspecified radius.
-ρ′ = magnitude(unit_icosphere[:point][begin])
-@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ′))
-# The definition of a discretization of a sphere of radius ρ.
-ρ = 1
-@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ))
-
-# The definition of a discretization of a sphere of unspecified radius.
-ρ′ = magnitude(thermo_icosphere[:point][begin])
-@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ′))
-ρ = 6371+90
-# The definition of a discretization of a sphere of radius ρ.
-@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ))
-
-# The definition of a discretization of a sphere of unspecified radius.
-ρ′ = magnitude(unit_uvsphere[:point][begin])
-@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ′))
-# The definition of a discretization of a sphere of radius ρ.
-ρ = 1
-@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ))
-
-# The definition of a discretization of a sphere of unspecified radius.
-ρ′ = magnitude(thermo_uvsphere[:point][begin])
-@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ′))
-# The definition of a discretization of a sphere of radius ρ.
-ρ = 6371+90
-@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ))
+#unit_icosphere = loadmesh(UnitIcosphere())
+#@test nv(unit_icosphere) == 2562
+#@test ne(unit_icosphere) == 7680
+#@test nparts(unit_icosphere, :Tri) == 5120
+#
+## Icosphere at minimum altitude of thermosphere
+#thermo_icosphere = loadmesh(ThermoIcosphere())
+#@test nv(thermo_icosphere) == 2562
+#@test ne(thermo_icosphere) == 7680
+#@test nparts(thermo_icosphere, :Tri) == 5120
+#
+## Unit UV sphere (TIE GCM grid)
+#unit_uvsphere = loadmesh(UnitUVSphere())
+#@test nv(unit_uvsphere) == 2522
+#@test ne(unit_uvsphere) == 7560
+#@test nparts(unit_uvsphere, :Tri) == 5040
+#
+## Icosphere at minimum altitude of thermosphere
+#thermo_uvsphere = loadmesh(ThermoUVSphere())
+#@test nv(thermo_uvsphere) == 2522
+#@test ne(thermo_uvsphere) == 7560
+#@test nparts(thermo_uvsphere, :Tri) == 5040
+#
+#
+#magnitude = (sqrt ∘ (x -> foldl(+, x*x)))
+#
+## The definition of a discretization of a sphere of unspecified radius.
+#ρ′ = magnitude(unit_icosphere[:point][begin])
+#@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ′))
+## The definition of a discretization of a sphere of radius ρ.
+#ρ = 1
+#@test all(isapprox.(magnitude.(unit_icosphere[:point]), ρ))
+#
+## The definition of a discretization of a sphere of unspecified radius.
+#ρ′ = magnitude(thermo_icosphere[:point][begin])
+#@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ′))
+#ρ = 6371+90
+## The definition of a discretization of a sphere of radius ρ.
+#@test all(isapprox.(magnitude.(thermo_icosphere[:point]), ρ))
+#
+## The definition of a discretization of a sphere of unspecified radius.
+#ρ′ = magnitude(unit_uvsphere[:point][begin])
+#@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ′))
+## The definition of a discretization of a sphere of radius ρ.
+#ρ = 1
+#@test all(isapprox.(magnitude.(unit_uvsphere[:point]), ρ))
+#
+## The definition of a discretization of a sphere of unspecified radius.
+#ρ′ = magnitude(thermo_uvsphere[:point][begin])
+#@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ′))
+## The definition of a discretization of a sphere of radius ρ.
+#ρ = 6371+90
+#@test all(isapprox.(magnitude.(thermo_uvsphere[:point]), ρ))
 
 end


### PR DESCRIPTION
Closes #68 

We kept the old tarball so as not to break any code on old commits that is relying on the previous url.
The unit icospheres are made available via:
```julia
loadmesh(UnitIcosphere1())
loadmesh(UnitIcosphere2())
loadmesh(UnitIcosphere3())
loadmesh(UnitIcosphere4())
loadmesh(UnitIcosphere5())
```