### PR TITLE
Use new Diagram typing scheme

### DIFF
--- a/src/Diagrams.jl
+++ b/src/Diagrams.jl
@@ -64,7 +64,8 @@ function parse_exp_diagram(cat, body; kw...)
       push!(new_body.args, exp)
     end
   end
-  parse_diagram(cat, new_body; kw...)
+  dec = parse_diagram(cat, new_body; kw...)
+  dec.diagram
 end
 
 i2sub = Dict(

--- a/src/Diagrams.jl
+++ b/src/Diagrams.jl
@@ -64,8 +64,7 @@ function parse_exp_diagram(cat, body; kw...)
       push!(new_body.args, exp)
     end
   end
-  dec = parse_diagram(cat, new_body; kw...)
-  dec.diagram
+  parse_diagram(cat, new_body; kw...)
 end
 
 i2sub = Dict(

--- a/src/OpenDiagrams.jl
+++ b/src/OpenDiagrams.jl
@@ -37,6 +37,10 @@ function OpenDiagram(F::FinDomFunctor, names::AbstractVector{Symbol})
   OpenDiagram(F, Multicospan(FinSet(1), legs))
 end
 
+function OpenDiagram(d::Diagram, args...)
+  OpenDiagram(diagram(d), args...)
+end
+
 const OpenFreeDiagramOb, OpenFreeDiagram = OpenACSetTypes(FreeDiagram, :V)
 
 OpenFreeDiagram(d::FreeDiagram{Ob,Hom}, args...) where {Ob,Hom} =

--- a/src/Schedules.jl
+++ b/src/Schedules.jl
@@ -238,4 +238,8 @@ function diag2dwd(diagram; clean = false, calc_states = [], out_vars=[], in_vars
   dwd
 end
 
+diag2dwd(simple_diagram::T; args...) where {T <: SimpleDiagram} =
+  diag2dwd(diagram(simple_diagram); args...)
+
+
 end


### PR DESCRIPTION
In Catlab version 0.14.9, the `@diagram` and `@free_diagram` macros return `Diagram`s.
The "old" Decapodes tooling in `src/OpenDiagrams.jl` and `src/Decapodes.jl` needed updating to use this type system.

The changes I made make all tests pass.
Interestingly, the `test/Decapodes.jl` tests passed just from adding the new constructor, because they pass to `diag2dwd` the `.functor` from the output of an `oapply`.
However, the `test/Examples.jl` tests failed because they pass to `diag2dwd` the output of the `@decapode` macro directly, which was now a `SimpleDiagram`. I made the `@decapode` macro simply grab the `.diagram` from the `SimpleDiagram` produced by `parse_diagram`.

It would probably be better to have `@decapode` return the same type that `parse_diagram` does, but I am going to de-prioritize that for the time being to work on using `Unitful` in the space weather examples.

@jpfairbanks Should I go ahead and pin `>= v0.14.9` for Catlab in the Project.toml for this branch?