### PR TITLE
Handle material properties as parameters instead of operators

### DIFF
--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -97,3 +97,11 @@ function expand_operators(d::SummationDecapode)
   expand_operators!(e, d)
   return e
 end
+
+function add_scalar!(d::AbstractNamedDecapode, k::Symbol)
+    return add_part!(d, :Var, type=:Scalar, name=k)
+end
+
+function add_parameter(d::AbstractNamedDecapode, k::Symbol)
+    return add_part!(d, :Var, type=:Parameter, name=k)
+end

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -98,8 +98,8 @@ function expand_operators(d::SummationDecapode)
   return e
 end
 
-function add_scalar!(d::AbstractNamedDecapode, k::Symbol)
-    return add_part!(d, :Var, type=:Scalar, name=k)
+function add_constant!(d::AbstractNamedDecapode, k::Symbol)
+    return add_part!(d, :Var, type=:Constant, name=k)
 end
 
 function add_parameter(d::AbstractNamedDecapode, k::Symbol)

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_scalar!, add_parameter,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_scalar!, add_parameter,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/simulation.jl
+++ b/src/Decapodes2/simulation.jl
@@ -81,7 +81,7 @@ infer_state_names(d) = d[infer_states(d), :name]
 function get_vars_code(d::AbstractNamedDecapode, vars::Vector{Symbol})
     stmts = map(vars) do s
         ssymbl = QuoteNode(s)
-        if all(d[incident(d, s, :name) , :type] .== :Scalar)
+        if all(d[incident(d, s, :name) , :type] .== :Constant)
             :($s = p.$s)
         elseif all(d[incident(d, s, :name) , :type] .== :Parameter)
             :($s = (p.$s)(t))

--- a/src/Decapodes2/simulation.jl
+++ b/src/Decapodes2/simulation.jl
@@ -62,10 +62,32 @@ Base.Expr(c::VarargsCall) = begin
     return :($(c.output) = $operator($(arglist...)))
 end
 
+function infer_states(d::AbstractNamedDecapode)
+    vars = map(parts(d, :Var)) do v
+        if length(incident(d, v, :tgt)) == 0 &&
+            length(incident(d, v, :res)) == 0 &&
+            length(incident(d, v, :sum)) == 0
+            # v isn't a derived value
+            return v
+        else
+            return nothing
+        end
+    end
+    return filter(!isnothing, vars)
+end
+
+infer_state_names(d) = d[infer_states(d), :name]
+
 function get_vars_code(d::AbstractNamedDecapode, vars::Vector{Symbol})
     stmts = map(vars) do s
         ssymbl = QuoteNode(s)
-        :($s = findnode(u, $ssymbl).values)
+        if all(d[incident(d, s, :name) , :type] .== :Scalar)
+            :($s = p.$s)
+        elseif all(d[incident(d, s, :name) , :type] .== :Parameter)
+            :($s = (p.$s)(t))
+        else
+            :($s = findnode(u, $ssymbl).values)
+        end
     end
     return quote $(stmts...) end
 end
@@ -81,6 +103,7 @@ function set_tanvars_code(d::AbstractNamedDecapode, statevars::Vector{Symbol})
 end
 
 function compile_env(d::AbstractNamedDecapode)
+  assumed_ops = Set([:+, :*, :-, :/])
   defs = quote end
   for op in d[:op1]
     if op == DerivOp
@@ -91,7 +114,7 @@ function compile_env(d::AbstractNamedDecapode)
     push!(defs.args, def)
   end
   for op in d[:op2]
-    if op == :+
+    if op in assumed_ops
       continue
     end
     ops = QuoteNode(op)
@@ -100,6 +123,8 @@ function compile_env(d::AbstractNamedDecapode)
   end
   return defs
 end
+
+gensim(d::AbstractNamedDecapode) = gensim(d, collect(infer_state_names(d)))
 
 function gensim(d::AbstractNamedDecapode, input_vars)
   d′ = expand_operators(d)
@@ -112,6 +137,8 @@ function gensim(d::AbstractNamedDecapode, input_vars)
     end
   end
 end
+
+compile(d::AbstractNamedDecapode) = compile(d, infer_state_names(d))
 
 function compile(d::NamedDecapode, inputs::Vector)
     input_numbers = incident(d, inputs, :name)
@@ -166,6 +193,7 @@ function compile(d::NamedDecapode, inputs::Vector)
         $(set_tanvars_code(d, inputs))
     end; end
 end
+
 function compile(d::SummationDecapode, inputs::Vector)
     input_numbers = incident(d, inputs, :name)
     visited = falses(nparts(d, :Var))

--- a/test/Decapodes2/multiscalearrays.jl
+++ b/test/Decapodes2/multiscalearrays.jl
@@ -46,10 +46,6 @@ function generate(sd, my_symbol)
 end
 
 
-meshpath(meshfile) = joinpath(@__DIR__, "meshes", meshfile)
-#plot_mesh = parse_json_acset(EmbeddedDeltaSet2D{Bool, Point3{Float64}}, read(meshpath("plot_mesh.json"), String))
-#periodic_mesh = parse_json_acset(EmbeddedDeltaDualComplex2D{Bool, Float64, Point3{Float64}}, read(meshpath("periodic_mesh.json"), String));
-#point_map = JSON.parse(read(meshpath("point_map.json"),String))
 plot_mesh = loadmesh(Rectangle_30x10())
 periodic_mesh = loadmesh(Torus_30x10())
 point_map = loadmesh(Point_Map())

--- a/test/Decapodes2/runtests.jl
+++ b/test/Decapodes2/runtests.jl
@@ -24,3 +24,6 @@ end
   include(joinpath(@__DIR__, "summation.jl"))
 end
 
+@testset "Simulation" begin
+  include(joinpath(@__DIR__, "simulation.jl"))
+end

--- a/test/Decapodes2/simulation.jl
+++ b/test/Decapodes2/simulation.jl
@@ -17,7 +17,7 @@ DiffusionExprBody =  quote
     # Fick's first law
     ϕ ==  ∘(k, d₀)(C)
     # Diffusion equation
-    Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+    Ċ == ∘(⋆₁, dual_d₁, ⋆₀⁻¹)(ϕ)
     ∂ₜ(C) == Ċ
 end
 
@@ -36,7 +36,7 @@ DiffusionExprBody =  quote
     # Fick's first law
     ϕ ==  k * d₀(C)
     # Diffusion equation
-    Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+    Ċ == ∘(⋆₁, dual_d₁, ⋆₀⁻¹)(ϕ)
     ∂ₜ(C) == Ċ
 end
 
@@ -60,7 +60,7 @@ DiffusionExprBody =  quote
     # Fick's first law
     ϕ ==  k * d₀(C)
     # Diffusion equation
-    Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+    Ċ == ∘(⋆₁, dual_d₁, ⋆₀⁻¹)(ϕ)
     ∂ₜ(C) == Ċ
 end
 

--- a/test/Decapodes2/simulation.jl
+++ b/test/Decapodes2/simulation.jl
@@ -1,0 +1,75 @@
+using Decapodes
+import Decapodes: compile, gensim, infer_states, infer_state_names
+
+using Catlab
+using Catlab.CategoricalAlgebra
+using Catlab.Graphics
+
+using Test
+
+@testset "Simulation Generation" begin
+
+DiffusionExprBody =  quote
+    C::Form0{X}
+    Ċ::Form0{X}
+    ϕ::Form1{X}
+
+    # Fick's first law
+    ϕ ==  ∘(k, d₀)(C)
+    # Diffusion equation
+    Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+    ∂ₜ(C) == Ċ
+end
+
+diffExpr = parse_decapode(DiffusionExprBody)
+ddp = SummationDecapode(diffExpr)
+add_scalar!(ddp, :k)
+@test nparts(ddp, :Var) == 4
+
+DiffusionExprBody =  quote
+    C::Form0{X}
+    Ċ::Form0{X}
+    ϕ::Form1{X}
+    k::Scalar{ℝ}
+
+
+    # Fick's first law
+    ϕ ==  k * d₀(C)
+    # Diffusion equation
+    Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+    ∂ₜ(C) == Ċ
+end
+
+diffExpr = parse_decapode(DiffusionExprBody)
+ddp = SummationDecapode(diffExpr)
+compile(expand_operators(ddp), [:C, :k])
+
+@test Decapodes.get_vars_code(ddp, [:k]).args[2] == :(k = p.k)
+@test infer_state_names(ddp) == [:C, :k]
+
+gensim(ddp)
+
+
+DiffusionExprBody =  quote
+    C::Form0{X}
+    Ċ::Form0{X}
+    ϕ::Form1{X}
+    k::Parameter{ℝ}
+
+
+    # Fick's first law
+    ϕ ==  k * d₀(C)
+    # Diffusion equation
+    Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+    ∂ₜ(C) == Ċ
+end
+
+diffExpr = parse_decapode(DiffusionExprBody)
+ddp = SummationDecapode(diffExpr)
+compile(expand_operators(ddp), [:C, :k])
+
+
+@test infer_state_names(ddp) == [:C, :k]
+@test Decapodes.get_vars_code(ddp, [:k]).args[2] == :(k = p.k(t))
+gensim(ddp)
+end

--- a/test/Decapodes2/simulation.jl
+++ b/test/Decapodes2/simulation.jl
@@ -13,7 +13,6 @@ using LinearAlgebra
 using Distributions
 using MultiScaleArrays
 
-@testset "Simulation Generation" begin
 function generate(sd, my_symbol)
   op = @match my_symbol begin
     :⋆₀ => x->⋆(0,sd,hodge=DiagonalHodge())*x
@@ -29,6 +28,7 @@ function generate(sd, my_symbol)
   return (args...) ->  op(args...)
 end
 
+@testset "Simulation Generation" begin
 DiffusionExprBody =  quote
     C::Form0{X}
     Ċ::Form0{X}
@@ -43,14 +43,14 @@ end
 
 diffExpr = parse_decapode(DiffusionExprBody)
 ddp = SummationDecapode(diffExpr)
-add_scalar!(ddp, :k)
+add_constant!(ddp, :k)
 @test nparts(ddp, :Var) == 4
 
 DiffusionExprBody =  quote
     C::Form0{X}
     Ċ::Form0{X}
     ϕ::Form1{X}
-    k::Scalar{ℝ}
+    k::Constant{ℝ}
 
 
     # Fick's first law


### PR DESCRIPTION
The operation of scaling by a constant is so ubiquitous that we need to handle it directly rather than relying on the previous encoding of constants as "the action of the constant on a vector". This PR adds support for constants, which are entries in the parameter named tuple that do not depend on time and Parameters which are parameters that do depend on time.