### PR TITLE
Explicit passing of operator construction

### DIFF
--- a/examples/sw/pressure.jl
+++ b/examples/sw/pressure.jl
@@ -111,7 +111,7 @@ physics = SummationDecapode(parse_decapode(PressureFlow))
 gensim(expand_operators(physics), [:P, :V])
 sim = eval(gensim(expand_operators(physics), [:P, :V]))
 
-fₘ = sim(earth)
+fₘ = sim(earth, generate)
 
 begin
   vmag = 500

--- a/examples/sw/sw.jl
+++ b/examples/sw/sw.jl
@@ -72,7 +72,7 @@ earth = EmbeddedDeltaDualComplex2D{Bool,Float64,Point3D}(primal_earth)
 subdivide_duals!(earth, Circumcenter())
 
 
-fₘ = f(earth)
+fₘ = f(earth, generate)
 c_dist = MvNormal(nploc[[1,2]], 100[1, 1])
 c = [pdf(c_dist, [p[1], p[2]]./√RADIUS) for p in earth[:point]]
 
@@ -114,7 +114,7 @@ advdiffdp = NamedDecapode(advdiff)
 gensim(expand_operators(advdiffdp), [:C, :V])
 sim = eval(gensim(expand_operators(advdiffdp), [:C, :V]))
 
-fₘ = sim(earth)
+fₘ = sim(earth, generate)
 end
 
 begin

--- a/examples/sw/sw_with_advection.jl
+++ b/examples/sw/sw_with_advection.jl
@@ -87,7 +87,7 @@ orient!(primal_earth)
 earth = EmbeddedDeltaDualComplex2D{Bool,Float64,Point3D}(primal_earth)
 subdivide_duals!(earth, Circumcenter())
 
-fₘ = f(earth)
+fₘ = f(earth, generate)
 c_dist = MvNormal(nploc[[1,2]], 100[1, 1])
 c = [pdf(c_dist, [p[1], p[2]]./√radius) for p in earth[:point]]
 v = ones(Float64, ne(earth))

--- a/src/Decapodes2/simulation.jl
+++ b/src/Decapodes2/simulation.jl
@@ -118,7 +118,7 @@ function compile_env(d::AbstractNamedDecapode)
       continue
     end
     ops = QuoteNode(op)
-    def = :($op = generate(mesh, $ops))
+    def = :($op = operators(mesh, $ops))
     push!(defs.args, def)
   end
   return defs
@@ -131,7 +131,7 @@ function gensim(d::AbstractNamedDecapode, input_vars)
   defs = compile_env(d′)
   rhs = compile(d′, input_vars)
   quote
-    function simulate(mesh)
+    function simulate(mesh, operators)
       $defs
       return $rhs
     end

--- a/test/Decapodes2/multiscalearrays.jl
+++ b/test/Decapodes2/multiscalearrays.jl
@@ -73,7 +73,7 @@ diffExpr = parse_decapode(DiffusionExprBody)
 ddp = SummationDecapode(diffExpr)
 gensim(expand_operators(ddp), [:C])
 f = eval(gensim(expand_operators(ddp), [:C]))
-fₘ = f(periodic_mesh)
+fₘ = f(periodic_mesh, generate)
 c_dist = MvNormal([5, 5], [1.5, 1.5])
 c = [pdf(c_dist, [p[1], p[2]]) for p in periodic_mesh[:point]]
 
@@ -123,7 +123,7 @@ Decapodes.compile(advdiffdp, [:C, :V])
 Decapodes.compile(expand_operators(advdiffdp), [:C, :V])
 gensim(expand_operators(advdiffdp), [:C, :V])
 sim = eval(gensim(expand_operators(advdiffdp), [:C, :V]))
-fₘ = sim(periodic_mesh)
+fₘ = sim(periodic_mesh, generate)
 velocity(p) = [-0.5, -0.5, 0.0]
 v = flat_op(periodic_mesh, DualVectorField(velocity.(periodic_mesh[triangle_center(periodic_mesh),:dual_point])); dims=[30, 10, Inf])
 c_dist = MvNormal([7, 5], [1.5, 1.5])

--- a/test/Decapodes2/simulation.jl
+++ b/test/Decapodes2/simulation.jl
@@ -77,7 +77,7 @@ u₀ = construct(PhysicsState, [VectorForm(c)],Float64[], [:C])
 du = construct(PhysicsState, [VectorForm(zero(c))],Float64[], [:C])
 
 f = eval(gensim(expand_operators(ddp)))
-fₘₛ = f(torus)
+fₘₛ = f(torus, generate)
 
 
 DiffusionExprBody =  quote
@@ -104,7 +104,7 @@ compile(expand_operators(ddp), [:C, :k])
 gensim(ddp)
 
 f = eval(gensim(expand_operators(ddp)))
-fₘₚ = f(torus)
+fₘₚ = f(torus, generate)
 
 @test norm(fₘₛ(du, u₀, (k=2.0,), 0)  - fₘₚ(du, u₀, (k=t->2.0,), 0)) < 1e-4
  


### PR DESCRIPTION
If the user wants to swap out the generate function between simulations, for example to change which hodge-star to use, this PR would pass that function in explicitly rather than assuming that the operator construction function is a global constant named `generate`. This is a breaking change because the output of `gensim` now requires two arguments.