### PR TITLE
Use Catlabv0.14.10 diagram parsing scheme

### DIFF
--- a/src/Diagrams.jl
+++ b/src/Diagrams.jl
@@ -7,7 +7,8 @@ using CombinatorialSpaces.ExteriorCalculus
 using Catlab
 using Catlab.CategoricalAlgebra
 using Catlab.Theories
-using Catlab.Programs.DiagrammaticPrograms: parse_diagram, parse_gat_expr
+using Catlab.Programs.DiagrammaticPrograms.AST
+using Catlab.Programs.DiagrammaticPrograms: parse_diagram, parse_gat_expr, parse_diagram_ast
 using Unicode
 
 export @decapode, Decapodes2D
@@ -26,7 +27,7 @@ relations within the Decapode.
 
 """
 macro decapode(cat, body)
-  :(parse_exp_diagram($(esc(cat)), $(Meta.quot(body)), free=true))
+  :(parse_exp_diagram($(esc(cat)), $(Meta.quot(body))))
 end
 
 function parse_exp_diagram(cat, body; kw...)
@@ -64,7 +65,8 @@ function parse_exp_diagram(cat, body; kw...)
       push!(new_body.args, exp)
     end
   end
-  parse_diagram(cat, new_body; kw...)
+  free_new_body = AST.Diagram(parse_diagram_ast(new_body, free=true))
+  parse_diagram(cat, free_new_body)
 end
 
 i2sub = Dict(


### PR DESCRIPTION
In Catlab version 0.14.10, the `free` keyword which distinguishes free from non-free diagrams is now a keyword given to the `AST.Diagram` constructor. Previously, this keyword was given to the diagram parsing function itself. This change broke the old decapodes parsing code when users update from v0.14.9.

This branch updates the old `src/Diagrams.jl` code to use this new parsing scheme. All tests pass.

Since this involves updating Catlab, this pull request is priority number one to get reviewed and merged for this project @jpfairbanks 