### PR TITLE
Llm/graphviz attrs

### DIFF
--- a/src/Decapodes2/visualization.jl
+++ b/src/Decapodes2/visualization.jl
@@ -20,21 +20,21 @@ end
 varname(d, v) = "$(d[v, :name]):$(spacename(d, v))"
 
 # TODO: Change orientation to print 
-Graphics.to_graphviz(F::AbstractDecapode; isDirected = true, orientation = LeftToRight, kw...) =
-to_graphviz(GraphvizGraphs.to_graphviz_property_graph(F; isDirected, kw...))
+Graphics.to_graphviz(F::AbstractDecapode; directed = true, kw...) =
+to_graphviz(GraphvizGraphs.to_graphviz_property_graph(F; directed, kw...))
 
 decapode_edge_label(s::Symbol) = String(s)
 decapode_edge_label(s::Vector{Symbol}) = join(String.(s), "⋅")
 
 
-function Catlab.Graphics.to_graphviz_property_graph(d::AbstractNamedDecapode, isDirected = true; kw...)
+function Catlab.Graphics.to_graphviz_property_graph(d::AbstractNamedDecapode, directed = true; kw...)
     pg = PropertyGraph{Any}(;kw...)
     vids = map(parts(d, :Var)) do v
       add_vertex!(pg, label=varname(d,v))
     end
 
     # Add entry and exit vertices and wires
-    if(isDirected)
+    if(directed)
       for state in infer_states(d)
         tempv = add_vertex!(pg)
         add_edge!(pg, tempv, vids[state])
@@ -53,7 +53,7 @@ function Catlab.Graphics.to_graphviz_property_graph(d::AbstractNamedDecapode, is
 
       # If in directed mode, sources point into the projection field
       # Else, everything points out
-      if(isDirected)
+      if(directed)
         add_edge!(pg, vids[s], v, label="π₁", style="dashed")
         add_edge!(pg, vids[t], v, label="π₂", style="dashed")
       else
@@ -66,30 +66,29 @@ function Catlab.Graphics.to_graphviz_property_graph(d::AbstractNamedDecapode, is
     return pg
 end
 
-function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; isDirected = true, node_attrs=Dict(), edge_attrs=Dict(), graph_attrs=Dict(), kw...)
-    #=tmp = NamedDecapode{Any, Any, Symbol}()
-    # FIXME we have to copy to cast
-    copy_parts!(tmp, d)
-    G = to_graphviz_property_graph(tmp, isDirected; kw...)
-    =#
+function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; directed = true, prog = "dot", node_attrs=Dict(), edge_attrs=Dict(), graph_attrs=Dict(), node_labels = true, kw...)
+    
+    default_graph_attrs = Dict(:rankdir => "TB")
+    default_edge_attrs = Dict()
+    default_node_attrs = Dict(:shape => "oval")
 
-    # prog = isDirected ? "dot" : "neato"
-    println(kw)
-    #G = PropertyGraph{Any}(;kw...)
-    G = to_graphviz_property_graph(Catlab.Graphs.Graph(0); node_attrs, edge_attrs, graph_attrs)
+    G = to_graphviz_property_graph(Catlab.Graphs.Graph(0); prog, node_labels,
+      node_attrs = merge!(default_node_attrs, node_attrs),  
+      edge_attrs = merge!(default_edge_attrs, edge_attrs),  
+      graph_attrs = merge!(default_graph_attrs, graph_attrs))
 
     vids = map(parts(d, :Var)) do v
       add_vertex!(G, label=varname(d,v))
     end
 
     # Add entry and exit vertices and wires
-    if(isDirected)
-      tempin = add_vertex!(G, shape = "egg", label = "nasonf")
+    if(directed)
+      tempin = add_vertex!(G, shape = "none", label = "")
       for state in infer_states(d)
         add_edge!(G, tempin, vids[state])
       end
 
-      tempout = add_vertex!(G, label = "nasonf")
+      tempout = add_vertex!(G, shape = "none", label = "")
       for tvar in d[:incl]
         add_edge!(G, vids[tvar], tempout)
       end
@@ -107,7 +106,7 @@ function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; isDire
 
       # If in directed mode, sources point into the projection field
       # Else, everything points out
-      if(isDirected)
+      if(directed)
         add_edge!(G, vids[s], v, label="π₁", style="dashed")
         add_edge!(G, vids[t], v, label="π₂", style="dashed")
       else
@@ -130,7 +129,7 @@ function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; isDire
     for e in parts(d, :Summand)
         # If directed, point summands into the sum
         # Else, everything points outward
-        if(isDirected)
+        if(directed)
           e = add_edge!(G, d[e, :summand], white_nodes[d[e, :summation]], style="dashed")
         else
           e = add_edge!(G, white_nodes[d[e, :summation]], d[e, :summand], style="dashed")

--- a/src/Decapodes2/visualization.jl
+++ b/src/Decapodes2/visualization.jl
@@ -3,7 +3,8 @@ import Catlab.Graphics.Graphviz
 using Catlab.Graphics
 using Catlab.Graphics.Graphviz
 using Catlab.Graphs.PropertyGraphs
-import Decapodes: infer_states, infer_state_names
+using Catlab.Graphs
+using Catlab.BasicGraphs
 
 reg_to_sub = Dict('0'=>'₀', '1'=>"₁", '2'=>'₂', '3'=>'₃', '4'=>'₄',
     '5'=>'₅', '6'=>'₆','7'=>'₇', '8'=>'₈', '9'=>'₉', 'r'=>'•')
@@ -65,15 +66,17 @@ function Catlab.Graphics.to_graphviz_property_graph(d::AbstractNamedDecapode, is
     return pg
 end
 
-function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; isDirected = true, kw...)
+function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; isDirected = true, node_attrs=Dict(), edge_attrs=Dict(), graph_attrs=Dict(), kw...)
     #=tmp = NamedDecapode{Any, Any, Symbol}()
     # FIXME we have to copy to cast
     copy_parts!(tmp, d)
     G = to_graphviz_property_graph(tmp, isDirected; kw...)
     =#
 
-    prog = isDirected ? "dot" : "neato"
-    G = PropertyGraph{Any}(prog = prog;kw...)
+    # prog = isDirected ? "dot" : "neato"
+    println(kw)
+    #G = PropertyGraph{Any}(;kw...)
+    G = to_graphviz_property_graph(Catlab.Graphs.Graph(0); node_attrs, edge_attrs, graph_attrs)
 
     vids = map(parts(d, :Var)) do v
       add_vertex!(G, label=varname(d,v))
@@ -81,12 +84,12 @@ function Catlab.Graphics.to_graphviz_property_graph(d::SummationDecapode; isDire
 
     # Add entry and exit vertices and wires
     if(isDirected)
-      tempin = add_vertex!(G, shape = "none", label = "")
+      tempin = add_vertex!(G, shape = "egg", label = "nasonf")
       for state in infer_states(d)
         add_edge!(G, tempin, vids[state])
       end
 
-      tempout = add_vertex!(G, shape = "none", label = "")
+      tempout = add_vertex!(G, label = "nasonf")
       for tvar in d[:incl]
         add_edge!(G, vids[tvar], tempout)
       end

--- a/src/Decapodes2/visualization.jl
+++ b/src/Decapodes2/visualization.jl
@@ -3,8 +3,9 @@ import Catlab.Graphics.Graphviz
 using Catlab.Graphics
 using Catlab.Graphics.Graphviz
 using Catlab.Graphs.PropertyGraphs
+import Decapodes: infer_states, infer_state_names
 using Catlab.Graphs
-using Catlab.BasicGraphs
+using Catlab.Graphs.BasicGraphs
 
 reg_to_sub = Dict('0'=>'₀', '1'=>"₁", '2'=>'₂', '3'=>'₃', '4'=>'₄',
     '5'=>'₅', '6'=>'₆','7'=>'₇', '8'=>'₈', '9'=>'₉', 'r'=>'•')

--- a/test/Decapodes2/visualization.jl
+++ b/test/Decapodes2/visualization.jl
@@ -12,31 +12,28 @@ DecaTest = quote
   
 Test1 = SummationDecapode(parse_decapode(DecaTest))
 t1 = to_graphviz(Test1)
-@test Graphviz.filter_statements(t1, Graphviz.Edge, :label) == ["k",
-  "p",
-  "+",
-  "+",
-  "+"]
-@test Graphviz.filter_statements(t1, Graphviz.Node, :label) == [
-  "A:Ω₀",
-  "B:Ω₀",
-  "C:Ω₀",
-  "D:Ω₀",
-  "•1:Ω•",
-  "sum_1:Ω•",
-  "•2:Ω•",
-  "sum_2:Ω•",
-  "",
-  "",
-  "Σ1",
-  "Σ2",
-  "Σ3" ]
-@test Graphviz.filter_statements(t1, Graphviz.Node, :shape) == [
-  "none",
-  "none",
-  "circle",
-  "circle",
-  "circle"]
+@test Graphviz.filter_statements(t1, Graphviz.Edge, :label) == ["k", "p", "+", "+", "+"]
+@test Graphviz.filter_statements(t1, Graphviz.Node, :label) == [ "A:Ω₀", "B:Ω₀", "C:Ω₀", "D:Ω₀", "•1:Ω•", "sum_1:Ω•", "•2:Ω•", "sum_2:Ω•", "", "", "Σ1", "Σ2", "Σ3" ]
+@test Graphviz.filter_statements(t1, Graphviz.Node, :shape) == [ "none", "none", "circle", "circle", "circle"]
+# Test that the default attributes are correct.
+@test t1.graph_attrs == Dict(:rankdir => "TB")
+@test t1.node_attrs == Dict(:height => "0.05", :margin => "0", :shape => "oval", :width => "0.05")
+
+t1_attributes = to_graphviz(Test1, edge_attrs=Dict(:color => "cornflowerblue"), node_attrs=Dict(:shape => "egg"), graph_attrs=Dict(:rankdir => "LR"))
+# Test that the default attributes are overwritten only where specified.
+@test t1_attributes.edge_attrs == Dict(:arrowsize => "0.5", :color => "cornflowerblue")
+@test t1_attributes.node_attrs == Dict(:height => "0.05", :margin => "0", :shape => "egg", :width => "0.05")
+@test t1_attributes.graph_attrs == Dict(:rankdir => "LR")
+# Test that the per-edge and per-node attributes are not overwritten.
+@test Graphviz.filter_statements(t1_attributes, Graphviz.Edge, :label) == ["k", "p", "+", "+", "+"]
+@test Graphviz.filter_statements(t1_attributes, Graphviz.Node, :label) == [ "A:Ω₀", "B:Ω₀", "C:Ω₀", "D:Ω₀", "•1:Ω•", "sum_1:Ω•", "•2:Ω•", "sum_2:Ω•", "", "", "Σ1", "Σ2", "Σ3" ]
+@test Graphviz.filter_statements(t1_attributes, Graphviz.Node, :shape) == [ "none", "none", "circle", "circle", "circle"]
+
+t1_no_default_changes = to_graphviz(Test1, node_attrs=Dict(:color => "red"), graph_attrs=Dict(:bgcolor => "fuchsia"))
+# Test that the default attributes are not overwritten when not specified.
+# (In this case, there should be no overwriting of default node shape, and graph rankdir.)
+@test t1_no_default_changes.node_attrs == Dict(:color => "red", :height => "0.05", :margin => "0", :shape => "oval", :width => "0.05")
+@test t1_no_default_changes.graph_attrs == Dict(:bgcolor => "fuchsia", :rankdir => "TB")
 
 DecaTest2 = quote
   A::Form0{X}

--- a/test/Decapodes2/visualization.jl
+++ b/test/Decapodes2/visualization.jl
@@ -55,7 +55,7 @@ t2 = to_graphviz(Test2)
 @test Graphviz.filter_statements(t2, Graphviz.Node, :label) == ["A:Ω₀", "B:Ω₀", "C:Ω₀", "D:Ω₀", "Ḋ:Ω•", "•1:Ω•", "•2:Ω•", "", "", "Ω₀×Ω₀", "Ω₀×Ω₀", "Σ1"]
 @test Graphviz.filter_statements(t2, Graphviz.Node, :shape) == ["none", "none", "rectangle", "rectangle", "circle"]
 
-t2_undirected = to_graphviz(Test2, isDirected = false)
+t2_undirected = to_graphviz(Test2, directed = false)
 @test Graphviz.filter_statements(t2_undirected, Graphviz.Edge, :label) == ["∂ₜ", "π₁", "π₂", "k", "π₁", "π₂", "p", "+"]
 @test Graphviz.filter_statements(t2_undirected, Graphviz.Node, :label) == ["A:Ω₀", "B:Ω₀", "C:Ω₀", "D:Ω₀", "Ḋ:Ω•", "•1:Ω•", "•2:Ω•", "Ω₀×Ω₀", "Ω₀×Ω₀", "Σ1"]
 @test Graphviz.filter_statements(t2_undirected, Graphviz.Node, :shape) == ["rectangle", "rectangle", "circle"]


### PR DESCRIPTION
This pull request adds support for specifying graphviz attributes when visualizing Decapodes.

Tests check that default attributes (such as node shape of oval, or graph layout of "TB") are only overwritten when specified (i.e. changing node color does not overwrite default node shape).