### PR TITLE
Type inference and overloading resolution via rewrites

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["James Fairbanks", "Andrew Baas", "Evan Patterson"]
 version = "0.1.1"
 
 [deps]
-AlgebraicRewriting = "725a01d3-f174-5bbd-84e1-b9417bad95d9"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 CombinatorialSpaces = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["James Fairbanks", "Andrew Baas", "Evan Patterson"]
 version = "0.1.1"
 
 [deps]
+AlgebraicRewriting = "725a01d3-f174-5bbd-84e1-b9417bad95d9"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 CombinatorialSpaces = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -120,228 +120,297 @@ function add_parameter(d::AbstractNamedDecapode, k::Symbol)
 end
 
 
+#"""
+#These are the default rewrite rules used to do type inference.
+#"""
+#default_type_inference_rules = [
+#  # The tgt of ∂ₜ is of the same type as its src.
+#  begin
+#    L = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; TVar = 1; Op1 = 1
+#
+#      type = [ARVar(:src_form), :infer]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      incl = [2]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:∂ₜ]
+#    end
+#    I = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 1
+#      type = [ARVar(:src_form)]
+#      name = [ARVar(:src_name)]
+#    end
+#    R = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; TVar = 1; Op1 = 1
+#
+#      type = [ARVar(:src_form), ARVar(:src_form)]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      incl = [2]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:∂ₜ]
+#    end
+#    hil = AlgebraicRewriting.homomorphism(I, L)
+#    hir = AlgebraicRewriting.homomorphism(I, R)
+#    Rule(hil, hir)
+#  end,
+#  # The src of ∂ₜ is of the same type as its tgt.
+#  begin
+#    L = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; TVar = 1; Op1 = 1
+#
+#      type = [:infer, ARVar(:tgt_form)]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      incl = [2]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:∂ₜ]
+#    end
+#    I = @acset SummationDecapode{Any, Any, Any} begin
+#      #Var = 1
+#      #type = [ARVar(:tgt_form)]
+#      #name = [ARVar(:tgt_name)]
+#      Var = 1; TVar = 1
+#      type = [ARVar(:tgt_form)]
+#      name = [ARVar(:tgt_name)]
+#      incl = [1]
+#    end
+#    R = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; TVar = 1; Op1 = 1
+#
+#      type = [ARVar(:tgt_form), ARVar(:tgt_form)]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      incl = [2]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:∂ₜ]
+#    end
+#    hil = AlgebraicRewriting.homomorphism(I, L)
+#    hir = AlgebraicRewriting.homomorphism(I, R)
+#    Rule(hil, hir)
+#  end,
+#  # The tgt of d of a Form0 is of the type Form1.
+#  begin
+#    L = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:Form0, :infer]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    I = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 1
+#      type = [:Form0]
+#      name = [ARVar(:src_name)]
+#    end
+#    R = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:Form0, :Form1]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    hil = AlgebraicRewriting.homomorphism(I, L)
+#    hir = AlgebraicRewriting.homomorphism(I, R)
+#    Rule(hil, hir)
+#  end,
+#  # The tgt of d of a Form1 is of the type Form2.
+#  begin
+#    L = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:Form1, :infer]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    I = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 1
+#      type = [:Form1]
+#      name = [ARVar(:src_name)]
+#    end
+#    R = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:Form1, :Form2]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    hil = AlgebraicRewriting.homomorphism(I, L)
+#    hir = AlgebraicRewriting.homomorphism(I, R)
+#    Rule(hil, hir)
+#  end,
+#  # The src of d of a Form1 is of the type Form0.
+#  begin
+#    L = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:infer, :Form1]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    I = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 1
+#      type = [:Form1]
+#      name = [ARVar(:tgt_name)]
+#    end
+#    R = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:Form0, :Form1]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    hil = AlgebraicRewriting.homomorphism(I, L)
+#    hir = AlgebraicRewriting.homomorphism(I, R)
+#    Rule(hil, hir)
+#  end,
+#  # The src of d of a Form2 is of the type Form1.
+#  begin
+#    L = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:infer, :Form2]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    I = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 1
+#      type = [:Form2]
+#      name = [ARVar(:tgt_name)]
+#    end
+#    R = @acset SummationDecapode{Any, Any, Any} begin
+#      Var = 2; Op1 = 1
+#
+#      type = [:Form1, :Form2]
+#      name = [ARVar(:src_name), ARVar(:tgt_name)]
+#      src = [1]
+#      tgt = [2]
+#      op1 = [:d]
+#    end
+#    hil = AlgebraicRewriting.homomorphism(I, L)
+#    hir = AlgebraicRewriting.homomorphism(I, R)
+#    Rule(hil, hir)
+#  end]
+#
+#function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}}; kw...)
+#  # Step 1: Convert to {Any,Any,Any} so we can use AlgebraicRewriting's Var.
+#  #d′ = migrate(SummationDecapode{Any, Any, Any}, d,
+#  #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
+#  #  Dict(:src => :src, :tgt => :tgt, :proj1 => :proj1, :proj2 => :proj2, :res => :res, :incl => :incl, :op1 => :op1, :op2 => :op2, :type => :type, :name => :name, :summand => :summand, :summation => :summation, :sum => :sum))
+#  d′ = migrate(SummationDecapode{Any, Any, Any}, d,
+#    merge(
+#      Dict(SchSummationDecapode.generators.Ob .=> SchSummationDecapode.generators.Ob),
+#      Dict(SchSummationDecapode.generators.AttrType .=> SchSummationDecapode.generators.AttrType)),
+#    merge(
+#      Dict(SchSummationDecapode.generators.Hom .=> SchSummationDecapode.generators.Hom),
+#      Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
+#
+#  # Step 2: Apply rules
+#  seq = Schedule[]
+#  append!(seq, RuleSchedule.(rules))
+#  #seq = Vector{Schedule}([RuleSchedule.(rules)])
+#  ar_step = ListSchedule(seq)
+#  end_condition(prev, curr) = :infer ∉ curr[:type]
+#  overall = WhileSchedule(ar_step, :main, end_condition)
+#  trajectory = apply_schedule(overall; G=d′, kw...)
+#  res = last(trajectory).G
+#  # Step 3: Convert back to {Any,Any,Symbol}.
+#  #migrate(SummationDecapode{Any, Any, Symbol}, res
+#  #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
+#  #  Dict(:src => :src, :tgt => :tgt, :proj1 => :proj1, :proj2 => :proj2, :res => :res, :incl => :incl, :op1 => :op1, :op2 => :op2, :type => :type, :name => :name, :summand => :summand, :summation => :summation, :sum => :sum))
+#  migrate(SummationDecapode{Any, Any, Symbol}, res,
+#    merge(
+#      Dict(SchSummationDecapode.generators.Ob .=> SchSummationDecapode.generators.Ob),
+#      Dict(SchSummationDecapode.generators.AttrType .=> SchSummationDecapode.generators.AttrType)),
+#    merge(
+#      Dict(SchSummationDecapode.generators.Hom .=> SchSummationDecapode.generators.Hom),
+#      Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
+#end
+#
+#infer_types(d::SummationDecapode; kw...) =
+#  infer_types(d, default_type_inference_rules; kw...)
+
+
 """
-These are the default rewrite rules used to do type inference.
+These are the default rules used to do type inference.
 """
 default_type_inference_rules = [
-  # The tgt of ∂ₜ is of the same type as its src.
-  begin
-    L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; TVar = 1; Op1 = 1
+  # Rules for ∂ₜ where tgt is unknown.
+  (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
+  (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
+  (src_type = :Form2, tgt_type = :infer, replacement_type = :Form2, op = :∂ₜ),
+  # Rules for ∂ₜ where src is unknown.
+  (src_type = :infer, tgt_type = :Form0, replacement_type = :Form0, op = :∂ₜ),
+  (src_type = :infer, tgt_type = :Form1, replacement_type = :Form1, op = :∂ₜ),
+  (src_type = :infer, tgt_type = :Form2, replacement_type = :Form2, op = :∂ₜ),
+  # Rules for d where tgt is unknown.
+  (src_type = :Form0, tgt_type = :infer, replacement_type = :Form1, op = :d),
+  (src_type = :Form1, tgt_type = :infer, replacement_type = :Form2, op = :d),
+  (src_type = :DualForm2, tgt_type = :infer, replacement_type = :DualForm1, op = :d),
+  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :DualForm0, op = :d),
+  # Rules for d where src is unknown.
+  (src_type = :infer, tgt_type = :Form2, replacement_type = :Form1, op = :d),
+  (src_type = :infer, tgt_type = :Form1, replacement_type = :Form0, op = :d),
+  (src_type = :infer, tgt_type = :DualForm0, replacement_type = :DualForm1, op = :d),
+  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :DualForm2, op = :d)]
 
-      type = [ARVar(:src_form), :infer]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      incl = [2]
-      src = [1]
-      tgt = [2]
-      op1 = [:∂ₜ]
-    end
-    I = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 1
-      type = [ARVar(:src_form)]
-      name = [ARVar(:src_name)]
-    end
-    R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; TVar = 1; Op1 = 1
+"""
+  function infer_types_helper(d::SummationDecapode, src_type, tgt_type, op::Symbol)
 
-      type = [ARVar(:src_form), ARVar(:src_form)]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      incl = [2]
-      src = [1]
-      tgt = [2]
-      op1 = [:∂ₜ]
-    end
-    hil = AlgebraicRewriting.homomorphism(I, L)
-    hir = AlgebraicRewriting.homomorphism(I, R)
-    Rule(hil, hir)
-  end,
-  # The src of ∂ₜ is of the same type as its tgt.
-  begin
-    L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; TVar = 1; Op1 = 1
+"""
+function infer_types_helper(d::SummationDecapode, src_type::Symbol, tgt_type::Symbol, replacement_type::Symbol, op::Symbol)
+  applied = false
+  if !xor(src_type == :infer, tgt_type == :infer)
+    error("Exactly one provided type must be :infer.")
+  end
+  for op1_idx in parts(d, :Op1)
+    src = d[:src][op1_idx]; tgt = d[:tgt][op1_idx]; op1 = d[:op1][op1_idx]
 
-      type = [:infer, ARVar(:tgt_form)]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      incl = [2]
-      src = [1]
-      tgt = [2]
-      op1 = [:∂ₜ]
+    if op1 == op && d[:type][src] == src_type && d[:type][tgt] == tgt_type
+      if src_type == :infer
+        d[:type][src] = replacement_type
+      else #if tgt_type == :infer
+        d[:type][tgt] = replacement_type
+      end
+      applied = true
+      break
     end
-    I = @acset SummationDecapode{Any, Any, Any} begin
-      #Var = 1
-      #type = [ARVar(:tgt_form)]
-      #name = [ARVar(:tgt_name)]
-      Var = 1; TVar = 1
-      type = [ARVar(:tgt_form)]
-      name = [ARVar(:tgt_name)]
-      incl = [1]
-    end
-    R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; TVar = 1; Op1 = 1
-
-      type = [ARVar(:tgt_form), ARVar(:tgt_form)]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      incl = [2]
-      src = [1]
-      tgt = [2]
-      op1 = [:∂ₜ]
-    end
-    hil = AlgebraicRewriting.homomorphism(I, L)
-    hir = AlgebraicRewriting.homomorphism(I, R)
-    Rule(hil, hir)
-  end,
-  # The tgt of d of a Form0 is of the type Form1.
-  begin
-    L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:Form0, :infer]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    I = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 1
-      type = [:Form0]
-      name = [ARVar(:src_name)]
-    end
-    R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:Form0, :Form1]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    hil = AlgebraicRewriting.homomorphism(I, L)
-    hir = AlgebraicRewriting.homomorphism(I, R)
-    Rule(hil, hir)
-  end,
-  # The tgt of d of a Form1 is of the type Form2.
-  begin
-    L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:Form1, :infer]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    I = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 1
-      type = [:Form1]
-      name = [ARVar(:src_name)]
-    end
-    R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:Form1, :Form2]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    hil = AlgebraicRewriting.homomorphism(I, L)
-    hir = AlgebraicRewriting.homomorphism(I, R)
-    Rule(hil, hir)
-  end,
-  # The src of d of a Form1 is of the type Form0.
-  begin
-    L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:infer, :Form1]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    I = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 1
-      type = [:Form1]
-      name = [ARVar(:tgt_name)]
-    end
-    R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:Form0, :Form1]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    hil = AlgebraicRewriting.homomorphism(I, L)
-    hir = AlgebraicRewriting.homomorphism(I, R)
-    Rule(hil, hir)
-  end,
-  # The src of d of a Form2 is of the type Form1.
-  begin
-    L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:infer, :Form2]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    I = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 1
-      type = [:Form2]
-      name = [ARVar(:tgt_name)]
-    end
-    R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2; Op1 = 1
-
-      type = [:Form1, :Form2]
-      name = [ARVar(:src_name), ARVar(:tgt_name)]
-      src = [1]
-      tgt = [2]
-      op1 = [:d]
-    end
-    hil = AlgebraicRewriting.homomorphism(I, L)
-    hir = AlgebraicRewriting.homomorphism(I, R)
-    Rule(hil, hir)
-  end]
-
-function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}}; kw...)
-  # Step 1: Convert to {Any,Any,Any} so we can use AlgebraicRewriting's Var.
-  #d′ = migrate(SummationDecapode{Any, Any, Any}, d,
-  #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
-  #  Dict(:src => :src, :tgt => :tgt, :proj1 => :proj1, :proj2 => :proj2, :res => :res, :incl => :incl, :op1 => :op1, :op2 => :op2, :type => :type, :name => :name, :summand => :summand, :summation => :summation, :sum => :sum))
-  d′ = migrate(SummationDecapode{Any, Any, Any}, d,
-    merge(
-      Dict(SchSummationDecapode.generators.Ob .=> SchSummationDecapode.generators.Ob),
-      Dict(SchSummationDecapode.generators.AttrType .=> SchSummationDecapode.generators.AttrType)),
-    merge(
-      Dict(SchSummationDecapode.generators.Hom .=> SchSummationDecapode.generators.Hom),
-      Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
-
-  # Step 2: Apply rules
-  seq = Schedule[]
-  append!(seq, RuleSchedule.(rules))
-  #seq = Vector{Schedule}([RuleSchedule.(rules)])
-  ar_step = ListSchedule(seq)
-  end_condition(prev, curr) = :infer ∉ curr[:type]
-  overall = WhileSchedule(ar_step, :main, end_condition)
-  trajectory = apply_schedule(overall; G=d′, kw...)
-  res = last(trajectory).G
-  # Step 3: Convert back to {Any,Any,Symbol}.
-  #migrate(SummationDecapode{Any, Any, Symbol}, res
-  #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
-  #  Dict(:src => :src, :tgt => :tgt, :proj1 => :proj1, :proj2 => :proj2, :res => :res, :incl => :incl, :op1 => :op1, :op2 => :op2, :type => :type, :name => :name, :summand => :summand, :summation => :summation, :sum => :sum))
-  migrate(SummationDecapode{Any, Any, Symbol}, res,
-    merge(
-      Dict(SchSummationDecapode.generators.Ob .=> SchSummationDecapode.generators.Ob),
-      Dict(SchSummationDecapode.generators.AttrType .=> SchSummationDecapode.generators.AttrType)),
-    merge(
-      Dict(SchSummationDecapode.generators.Hom .=> SchSummationDecapode.generators.Hom),
-      Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
+  end
+  return applied
 end
 
-infer_types(d::SummationDecapode; kw...) =
-  infer_types(d, default_type_inference_rules; kw...)
+"""
+  function infer_types!(d::SummationDecapode, rules::Vector{NamedTuple{(:src_type, :tgt_type, :replacement_type, :op), NTuple{4, Symbol}}})
+
+Infer types of Vars given rules wherein one type is known and the other not.
+"""
+function infer_types!(d::SummationDecapode, rules::Vector{NamedTuple{(:src_type, :tgt_type, :replacement_type, :op), NTuple{4, Symbol}}})
+  while true
+    applied = false
+    for rule in rules
+      applied = infer_types_helper(d, rule...)
+      applied && break # Break if a rule was applied.
+    end
+    applied || break # Break if no rules were applied.
+  end
+  d
+end
+
+infer_types!(d::SummationDecapode) =
+  infer_types!(d, default_type_inference_rules)
 

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -1,5 +1,5 @@
-using AlgebraicRewriting
-using AlgebraicRewriting: Var as ARVar
+#using AlgebraicRewriting
+#using AlgebraicRewriting: Var as ARVar
 
 @present SchDecapode(FreeSchema) begin
     (Var, TVar, Op1, Op2)::Ob
@@ -351,6 +351,7 @@ end
 These are the default rules used to do type inference in the 2D exterior calculus.
 """
 default_type_inference_rules_2D = [
+  # TODO: There are rules for op2s that must be written still.
   # Rules for ∂ₜ where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
@@ -383,10 +384,12 @@ default_type_inference_rules_2D = [
   (src_type = :infer, tgt_type = :Form0, replacement_type = :DualForm2, op = :⋆),
   (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm1, op = :⋆),
   (src_type = :infer, tgt_type = :Form2, replacement_type = :DualForm0, op = :⋆)]
+
 """
 These are the default rules used to do type inference in the 1D exterior calculus.
 """
 default_type_inference_rules_1D = [
+  # TODO: There are rules for op2s that must be written still.
   # Rules for ∂ₜ where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
@@ -464,6 +467,65 @@ function infer_types!(d::SummationDecapode, rules::Vector{NamedTuple{(:src_type,
   d
 end
 
+# TODO: When SummationDecapodes are annotated with the degree of their space,
+# use dispatch to choose the correct set of rules.
 infer_types!(d::SummationDecapode) =
   infer_types!(d, default_type_inference_rules_2D)
+
+# TODO: You could write a method which auto-generates these rules given degree N.
+"""
+These are the default rules used to do function resolution in the 2D exterior calculus.
+"""
+default_overloading_resolution_rules_2D = [
+  # TODO: There are rules for op2s that must be written still.
+  # Rules for d.
+  (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
+  (src_type = :Form1, tgt_type = :Form2, resolved_name = :d₁, op = :d),
+  (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
+  (src_type = :DualForm1, tgt_type = :DualForm2, resolved_name = :dual_d₁, op = :d),
+  # Rules for ⋆.
+  (src_type = :Form0, tgt_type = :DualForm2, resolved_name = :⋆₀, op = :⋆),
+  (src_type = :Form1, tgt_type = :DualForm1, resolved_name = :⋆₁, op = :⋆),
+  (src_type = :Form2, tgt_type = :DualForm0, resolved_name = :⋆₂, op = :⋆),
+  (src_type = :DualForm2, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
+  (src_type = :DualForm1, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
+  (src_type = :DualForm0, tgt_type = :Form2, resolved_name = :⋆₂⁻¹, op = :⋆)]
+
+"""
+These are the default rules used to do function resolution in the 1D exterior calculus.
+"""
+default_overloading_resolution_rules_1D = [
+  # TODO: There are rules for op2s that must be written still.
+  # Rules for d.
+  (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
+  (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
+  # Rules for ⋆.
+  (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :⋆),
+  (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :⋆),
+  (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
+  (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆)]
+
+"""
+  function resolve_overloads!(d::SummationDecapode, rules::Vector{NamedTuple{(:src_type, :tgt_type, :resolved_name, :op), NTuple{4, Symbol}}})
+
+Resolve function overloads based on types of src and tgt.
+"""
+function resolve_overloads!(d::SummationDecapode, rules::Vector{NamedTuple{(:src_type, :tgt_type, :resolved_name, :op), NTuple{4, Symbol}}})
+  for op1_idx in parts(d, :Op1)
+    src = d[:src][op1_idx]; tgt = d[:tgt][op1_idx]; op1 = d[:op1][op1_idx]
+    src_type = d[:type][src]; tgt_type = d[:type][tgt]
+    for rule in rules
+      if op1 == rule[:op] && src_type == rule[:src_type] && tgt_type == rule[:tgt_type]
+        d[:op1][op1_idx] = rule[:resolved_name]
+        break
+      end
+    end
+  end
+  d
+end
+
+# TODO: When SummationDecapodes are annotated with the degree of their space,
+# use dispatch to choose the correct set of rules.
+resolve_overloads!(d::SummationDecapode) =
+  resolve_overloads!(d, default_overloading_resolution_rules_2D)
 

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -346,40 +346,6 @@ end
 #  infer_types(d, default_op1_type_inference_rules; kw...)
 
 
-function expand_compositions!(d::SummationDecapode)
-  max_anon = 1
-  for op1_idx in parts(d, :Op1)
-    op1 = string(d[:op1])
-    op1[1] != '•' && continue
-    num = parse(Integer, op1[4:end])
-    if max_anon < num
-      max_anon = num
-    end
-  end
-  curr_anon = max_anon
-  for op1_idx in parts(d, :Op1)
-    op1 = d[:op1][op1_idx]
-    typeof(op1) == Vector{Symbol} || continue
-    prev_var_added_idx = d[:src][op1_idx]
-    for op in op1[1:end-1]
-      # Add a new intermediate var.
-      curr_var_added_idx = add_part!(d, :Var)
-      d[:type][curr_var_added_idx] = :infer
-      d[:name][curr_var_added_idx] = Symbol('•', curr_anon)
-      curr_anon += 1
-      # Add a new intermediate op.
-      curr_op1_added_idx = add_part!(d, :Op1)
-      d[:op1][curr_op1_added_idx] = op
-      d[:src][curr_op1_added_idx] = prev_var_added_idx
-      d[:tgt][curr_op1_added_idx] = curr_var_added_idx
-      prev_var_added_idx = curr_var_added_idx
-    end
-    d[:op1][op1_idx] = last(d[:op1][op1_idx])
-    d[:src][op1_idx] = prev_var_added_idx
-  end
-  d
-end
-
 # TODO: You could write a method which auto-generates these rules given degree N.
 """
 These are the default rules used to do type inference in the 2D exterior calculus.

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -119,239 +119,11 @@ function add_parameter(d::AbstractNamedDecapode, k::Symbol)
     return add_part!(d, :Var, type=:Parameter, name=k)
 end
 
-
-#"""
-#These are the default rewrite rules used to do type inference.
-#"""
-#default_op1_type_inference_rules = [
-#  # The tgt of ∂ₜ is of the same type as its src.
-#  begin
-#    L = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; TVar = 1; Op1 = 1
-#
-#      type = [ARVar(:src_form), :infer]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      incl = [2]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:∂ₜ]
-#    end
-#    I = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 1
-#      type = [ARVar(:src_form)]
-#      name = [ARVar(:src_name)]
-#    end
-#    R = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; TVar = 1; Op1 = 1
-#
-#      type = [ARVar(:src_form), ARVar(:src_form)]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      incl = [2]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:∂ₜ]
-#    end
-#    hil = AlgebraicRewriting.homomorphism(I, L)
-#    hir = AlgebraicRewriting.homomorphism(I, R)
-#    Rule(hil, hir)
-#  end,
-#  # The src of ∂ₜ is of the same type as its tgt.
-#  begin
-#    L = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; TVar = 1; Op1 = 1
-#
-#      type = [:infer, ARVar(:tgt_form)]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      incl = [2]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:∂ₜ]
-#    end
-#    I = @acset SummationDecapode{Any, Any, Any} begin
-#      #Var = 1
-#      #type = [ARVar(:tgt_form)]
-#      #name = [ARVar(:tgt_name)]
-#      Var = 1; TVar = 1
-#      type = [ARVar(:tgt_form)]
-#      name = [ARVar(:tgt_name)]
-#      incl = [1]
-#    end
-#    R = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; TVar = 1; Op1 = 1
-#
-#      type = [ARVar(:tgt_form), ARVar(:tgt_form)]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      incl = [2]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:∂ₜ]
-#    end
-#    hil = AlgebraicRewriting.homomorphism(I, L)
-#    hir = AlgebraicRewriting.homomorphism(I, R)
-#    Rule(hil, hir)
-#  end,
-#  # The tgt of d of a Form0 is of the type Form1.
-#  begin
-#    L = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:Form0, :infer]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    I = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 1
-#      type = [:Form0]
-#      name = [ARVar(:src_name)]
-#    end
-#    R = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:Form0, :Form1]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    hil = AlgebraicRewriting.homomorphism(I, L)
-#    hir = AlgebraicRewriting.homomorphism(I, R)
-#    Rule(hil, hir)
-#  end,
-#  # The tgt of d of a Form1 is of the type Form2.
-#  begin
-#    L = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:Form1, :infer]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    I = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 1
-#      type = [:Form1]
-#      name = [ARVar(:src_name)]
-#    end
-#    R = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:Form1, :Form2]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    hil = AlgebraicRewriting.homomorphism(I, L)
-#    hir = AlgebraicRewriting.homomorphism(I, R)
-#    Rule(hil, hir)
-#  end,
-#  # The src of d of a Form1 is of the type Form0.
-#  begin
-#    L = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:infer, :Form1]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    I = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 1
-#      type = [:Form1]
-#      name = [ARVar(:tgt_name)]
-#    end
-#    R = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:Form0, :Form1]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    hil = AlgebraicRewriting.homomorphism(I, L)
-#    hir = AlgebraicRewriting.homomorphism(I, R)
-#    Rule(hil, hir)
-#  end,
-#  # The src of d of a Form2 is of the type Form1.
-#  begin
-#    L = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:infer, :Form2]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    I = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 1
-#      type = [:Form2]
-#      name = [ARVar(:tgt_name)]
-#    end
-#    R = @acset SummationDecapode{Any, Any, Any} begin
-#      Var = 2; Op1 = 1
-#
-#      type = [:Form1, :Form2]
-#      name = [ARVar(:src_name), ARVar(:tgt_name)]
-#      src = [1]
-#      tgt = [2]
-#      op1 = [:d]
-#    end
-#    hil = AlgebraicRewriting.homomorphism(I, L)
-#    hir = AlgebraicRewriting.homomorphism(I, R)
-#    Rule(hil, hir)
-#  end]
-#
-#function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}}; kw...)
-#  # Step 1: Convert to {Any,Any,Any} so we can use AlgebraicRewriting's Var.
-#  #d′ = migrate(SummationDecapode{Any, Any, Any}, d,
-#  #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
-#  #  Dict(:src => :src, :tgt => :tgt, :proj1 => :proj1, :proj2 => :proj2, :res => :res, :incl => :incl, :op1 => :op1, :op2 => :op2, :type => :type, :name => :name, :summand => :summand, :summation => :summation, :sum => :sum))
-#  d′ = migrate(SummationDecapode{Any, Any, Any}, d,
-#    merge(
-#      Dict(SchSummationDecapode.generators.Ob .=> SchSummationDecapode.generators.Ob),
-#      Dict(SchSummationDecapode.generators.AttrType .=> SchSummationDecapode.generators.AttrType)),
-#    merge(
-#      Dict(SchSummationDecapode.generators.Hom .=> SchSummationDecapode.generators.Hom),
-#      Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
-#
-#  # Step 2: Apply rules
-#  seq = Schedule[]
-#  append!(seq, RuleSchedule.(rules))
-#  #seq = Vector{Schedule}([RuleSchedule.(rules)])
-#  ar_step = ListSchedule(seq)
-#  end_condition(prev, curr) = :infer ∉ curr[:type]
-#  overall = WhileSchedule(ar_step, :main, end_condition)
-#  trajectory = apply_schedule(overall; G=d′, kw...)
-#  res = last(trajectory).G
-#  # Step 3: Convert back to {Any,Any,Symbol}.
-#  #migrate(SummationDecapode{Any, Any, Symbol}, res
-#  #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
-#  #  Dict(:src => :src, :tgt => :tgt, :proj1 => :proj1, :proj2 => :proj2, :res => :res, :incl => :incl, :op1 => :op1, :op2 => :op2, :type => :type, :name => :name, :summand => :summand, :summation => :summation, :sum => :sum))
-#  migrate(SummationDecapode{Any, Any, Symbol}, res,
-#    merge(
-#      Dict(SchSummationDecapode.generators.Ob .=> SchSummationDecapode.generators.Ob),
-#      Dict(SchSummationDecapode.generators.AttrType .=> SchSummationDecapode.generators.AttrType)),
-#    merge(
-#      Dict(SchSummationDecapode.generators.Hom .=> SchSummationDecapode.generators.Hom),
-#      Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
-#end
-#
-#infer_types(d::SummationDecapode; kw...) =
-#  infer_types(d, default_op1_type_inference_rules; kw...)
-
-
 # TODO: You could write a method which auto-generates these rules given degree N.
 """
 These are the default rules used to do type inference in the 1D exterior calculus.
 """
-default_op1_type_inference_rules_1D = [
-  # TODO: There are rules for op2s that must be written still.
+op1_inf_rules_1D = [
   # Rules for ∂ₜ where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
@@ -375,7 +147,7 @@ default_op1_type_inference_rules_1D = [
   (src_type = :infer, tgt_type = :Form0, replacement_type = :DualForm1, op = :⋆),
   (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm0, op = :⋆)]
 
-default_op2_type_inference_rules_1D = [
+op2_inf_rules_1D = [
   # Rules for ∧ where proj1 is unknown. ∧₀₀, ∧₁₀, ∧₀₁
   (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form0, op = :∧),
   (proj1_type = :infer, proj2_type = :Form0, res_type = :Form1, replacement_type = :Form1, op = :∧),
@@ -389,7 +161,6 @@ default_op2_type_inference_rules_1D = [
   (proj1_type = :Form1, proj2_type = :Form0, res_type = :infer, replacement_type = :Form1, op = :∧),
   (proj1_type = :Form0, proj2_type = :Form1, res_type = :infer, replacement_type = :Form1, op = :∧),
 
-  # TODO: Overhaul since L apparently always needs a Form1 as it's first input
   # Rules for L where proj1 is unknown. L₀, L₁
   (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
   (proj1_type = :infer, proj2_type = :Form1, res_type = :Form1, replacement_type = :Form1, op = :L),    
@@ -410,7 +181,7 @@ default_op2_type_inference_rules_1D = [
 """
 These are the default rules used to do type inference in the 2D exterior calculus.
 """
-default_op1_type_inference_rules_2D = [
+op1_inf_rules_2D = [
   # Rules for ∂ₜ where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
@@ -446,7 +217,7 @@ default_op1_type_inference_rules_2D = [
 
 # WARNING: I'm combining 1D and 2D rules directly here since it seems op2 rules
 # are metric-free. If for some reason we can't make this assumption, this needs to change
-default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, [
+op2_inf_rules_2D = vcat(op2_inf_rules_1D, [
   # Rules for ∧ where proj1 is unknown. ∧₁₁, ∧₂₀, ∧₀₂
   (proj1_type = :infer, proj2_type = :Form1, res_type = :Form2, replacement_type = :Form1, op = :∧),
   (proj1_type = :infer, proj2_type = :Form0, res_type = :Form2, replacement_type = :Form2, op = :∧),
@@ -460,7 +231,6 @@ default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, 
   (proj1_type = :Form2, proj2_type = :Form0, res_type = :infer, replacement_type = :Form2, op = :∧),
   (proj1_type = :Form0, proj2_type = :Form2, res_type = :infer, replacement_type = :Form2, op = :∧),
 
-  # TODO: Overhaul since L apparently always needs a Form1 as it's first input
   # Rules for L where proj1 is unknown. L₂
   (proj1_type = :infer, proj2_type = :Form2, res_type = :Form2, replacement_type = :Form1, op = :L),
   # Rules for L where proj2 is unknown. L₂
@@ -468,7 +238,6 @@ default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, 
   # Rules for L where res is unknown. L₂
   (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form2, op = :L),
 
-  # TODO: Similar issue for i, where i always needs a Form1 as it's first input
   # Rules for i where proj1 is unknown. i₁
   (proj1_type = :infer, proj2_type = :Form2, res_type = :Form1, replacement_type = :Form1, op = :i),
   # Rules for i where proj2 is unknown. i₁
@@ -528,7 +297,7 @@ end
 
 function apply_op2_type_rules!(d::SummationDecapode, types_known::Vector{Bool}, proj1_type::Symbol, proj2_type::Symbol, res_type::Symbol, replacement_type::Symbol, op::Symbol)
   applied = false
-  # TODO: May want to add that an inference rule is valid, so that at least some variable is an infer type
+  # TODO: May want to add a check that an inference rule is valid, (at least some variable is an infer type.)
 
   for op2_idx in parts(d, :Op2)
     types_known[op2_idx] && continue
@@ -583,7 +352,6 @@ function infer_types!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(:src_t
       applied = applied || this_applied
     end
 
-    # TODO: Infer Op2 types.
     for rule in op2_rules
       this_applied = apply_op2_type_rules!(d, types_known_op2, rule...)
       applied = applied || this_applied
@@ -599,14 +367,14 @@ end
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 infer_types!(d::SummationDecapode) =
-  infer_types!(d, default_op1_type_inference_rules_2D, default_op2_type_inference_rules_2D)
+  infer_types!(d, op1_inf_rules_2D, op2_inf_rules_2D)
 
 # TODO: You could write a method which auto-generates these rules given degree N.
 
 """
 These are the default rules used to do function resolution in the 1D exterior calculus.
 """
-default_op1_overloading_resolution_rules_1D = [
+op1_res_rules_1D = [
   # Rules for d.
   (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
   (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
@@ -618,7 +386,9 @@ default_op1_overloading_resolution_rules_1D = [
   # Rules for δ.
   (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ)]
 
-default_op2_overloading_resolution_rules_1D = [
+# We merge 1D and 2D rules since it seems op2 rules are metric-free. If
+# this assumption is false, this needs to change.
+op2_res_rules_1D = [
   # Rules for ∧.
   (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, resolved_name = :∧₀₀, op = :∧),
   (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form1, resolved_name = :∧₁₀, op = :∧),
@@ -633,7 +403,7 @@ default_op2_overloading_resolution_rules_1D = [
 """
 These are the default rules used to do function resolution in the 2D exterior calculus.
 """
-default_op1_overloading_resolution_rules_2D = [
+op1_res_rules_2D = [
   # Rules for d.
   (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
   (src_type = :Form1, tgt_type = :Form2, resolved_name = :d₁, op = :d),
@@ -658,9 +428,9 @@ default_op1_overloading_resolution_rules_2D = [
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :Δ)]
 
-# WARNING: I'm combining 1D and 2D rules directly here since it seems op2 rules
-# are metric-free. If for some reason we can't make this assumption, this needs to change
-default_op2_overloading_resolution_rules_2D = vcat(default_op2_overloading_resolution_rules_1D, [
+# We merge 1D and 2D rules directly here since it seems op2 rules
+# are metric-free. If this assumption is false, this needs to change.
+op2_res_rules_2D = vcat(op2_res_rules_1D, [
   # Rules for ∧.
   (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form2, resolved_name = :∧₁₁, op = :∧),
   (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, resolved_name = :∧₂₀, op = :∧),
@@ -704,6 +474,6 @@ end
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 resolve_overloads!(d::SummationDecapode) =
-  resolve_overloads!(d, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_2D)
+  resolve_overloads!(d, op1_res_rules_2D, op2_res_rules_2D)
 
 +

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -411,7 +411,6 @@ default_op2_type_inference_rules_1D = [
 These are the default rules used to do type inference in the 2D exterior calculus.
 """
 default_op1_type_inference_rules_2D = [
-  # TODO: There are rules for op2s that must be written still.
   # Rules for ∂ₜ where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
@@ -635,7 +634,6 @@ default_op2_overloading_resolution_rules_1D = [
 These are the default rules used to do function resolution in the 2D exterior calculus.
 """
 default_op1_overloading_resolution_rules_2D = [
-  # TODO: There are rules for op2s that must be written still.
   # Rules for d.
   (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
   (src_type = :Form1, tgt_type = :Form2, resolved_name = :d₁, op = :d),
@@ -655,7 +653,7 @@ default_op1_overloading_resolution_rules_2D = [
   (src_type = :Form0, tgt_type = :Form0, resolved_name = :∇²₀, op = :∇²),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :∇²₁, op = :∇²),
   (src_type = :Form2, tgt_type = :Form2, resolved_name = :∇²₂, op = :∇²),
-  # Rules for Δ².
+  # Rules for Δ.
   (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :Δ)]

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -659,6 +659,19 @@ default_op1_overloading_resolution_rules_2D = [
   (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :Δ)]
+
+# WARNING: I'm combining 1D and 2D rules directly here since it seems op2 rules
+# are metric-free. If for some reason we can't make this assumption, this needs to change
+default_op2_overloading_resolution_rules_2D = vcat(default_op2_overloading_resolution_rules_1D, [
+  # Rules for ∧.
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form2, resolved_name = :∧₁₁, op = :∧),
+  (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, resolved_name = :∧₂₀, op = :∧),
+  (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, resolved_name = :∧₀₂, op = :∧),
+  # Rules for L.
+  (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form2, resolved_name = :L₂, op = :L),
+  # Rules for i.
+  (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form1, resolved_name = :i₂, op = :i)])
+  
 """
   function resolve_overloads!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(:src_type, :tgt_type, :resolved_name, :op), NTuple{4, Symbol}}})
 
@@ -693,5 +706,5 @@ end
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 resolve_overloads!(d::SummationDecapode) =
-  resolve_overloads!(d, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_1D)
+  resolve_overloads!(d, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_2D)
 

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -375,37 +375,37 @@ default_op1_type_inference_rules_1D = [
   (src_type = :infer, tgt_type = :Form0, replacement_type = :DualForm1, op = :⋆),
   (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm0, op = :⋆)]
 
-  default_op2_type_inference_rules_1D = [
-    # Rules for ∧ where proj1 is unknown. ∧₀₀, ∧₁₀, ∧₀₁
-    (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form0, op = :∧),
-    (proj1_type = :infer, proj2_type = :Form0, res_type = :Form1, replacement_type = :Form1, op = :∧),
-    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form1, replacement_type = :Form0, op = :∧),
-    # Rules for ∧ where proj2 is unknown. ∧₀₀, ∧₁₀, ∧₀₁
-    (proj1_type = :Form0, proj2_type = :infer, res_type = :Form0, replacement_type = :Form0, op = :∧),
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form0, op = :∧),
-    (proj1_type = :Form0, proj2_type = :infer, res_type = :Form1, replacement_type = :Form1, op = :∧),
-    # Rules for ∧ where res is unknown. ∧₀₀, ∧₁₀, ∧₀₁
-    (proj1_type = :Form0, proj2_type = :Form0, res_type = :infer, replacement_type = :Form0, op = :∧),
-    (proj1_type = :Form1, proj2_type = :Form0, res_type = :infer, replacement_type = :Form1, op = :∧),
-    (proj1_type = :Form0, proj2_type = :Form1, res_type = :infer, replacement_type = :Form1, op = :∧),
+default_op2_type_inference_rules_1D = [
+  # Rules for ∧ where proj1 is unknown. ∧₀₀, ∧₁₀, ∧₀₁
+  (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form0, op = :∧),
+  (proj1_type = :infer, proj2_type = :Form0, res_type = :Form1, replacement_type = :Form1, op = :∧),
+  (proj1_type = :infer, proj2_type = :Form1, res_type = :Form1, replacement_type = :Form0, op = :∧),
+  # Rules for ∧ where proj2 is unknown. ∧₀₀, ∧₁₀, ∧₀₁
+  (proj1_type = :Form0, proj2_type = :infer, res_type = :Form0, replacement_type = :Form0, op = :∧),
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form0, op = :∧),
+  (proj1_type = :Form0, proj2_type = :infer, res_type = :Form1, replacement_type = :Form1, op = :∧),
+  # Rules for ∧ where res is unknown. ∧₀₀, ∧₁₀, ∧₀₁
+  (proj1_type = :Form0, proj2_type = :Form0, res_type = :infer, replacement_type = :Form0, op = :∧),
+  (proj1_type = :Form1, proj2_type = :Form0, res_type = :infer, replacement_type = :Form1, op = :∧),
+  (proj1_type = :Form0, proj2_type = :Form1, res_type = :infer, replacement_type = :Form1, op = :∧),
 
-    # TODO: Overhaul since L apparently always needs a Form1 as it's first input
-    # Rules for L where proj1 is unknown. L₀, L₁
-    (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
-    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form1, replacement_type = :Form1, op = :L),    
-    # Rules for L where proj2 is unknown. L₀, L₁
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form0, replacement_type = :Form0, op = :L),
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form1, op = :L),    
-    # Rules for L where res is unknown. L₀, L₁
-    (proj1_type = :Form1, proj2_type = :Form0, res_type = :infer, replacement_type = :Form0, op = :L),
-    (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form1, op = :L),   
+  # TODO: Overhaul since L apparently always needs a Form1 as it's first input
+  # Rules for L where proj1 is unknown. L₀, L₁
+  (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
+  (proj1_type = :infer, proj2_type = :Form1, res_type = :Form1, replacement_type = :Form1, op = :L),    
+  # Rules for L where proj2 is unknown. L₀, L₁
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form0, replacement_type = :Form0, op = :L),
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form1, op = :L),    
+  # Rules for L where res is unknown. L₀, L₁
+  (proj1_type = :Form1, proj2_type = :Form0, res_type = :infer, replacement_type = :Form0, op = :L),
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form1, op = :L),   
 
-    # Rules for i where proj1 is unknown. i₁
-    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form0, replacement_type = :Form1, op = :i),
-    # Rules for i where proj2 is unknown. i₁
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :infer, replacement_type = :Form0, op = :i),
-    # Rules for i where res is unknown. i₁
-    (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form0, op = :i)]
+  # Rules for i where proj1 is unknown. i₁
+  (proj1_type = :infer, proj2_type = :Form1, res_type = :Form0, replacement_type = :Form1, op = :i),
+  # Rules for i where proj2 is unknown. i₁
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :infer, replacement_type = :Form0, op = :i),
+  # Rules for i where res is unknown. i₁
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form0, op = :i)]
 
 """
 These are the default rules used to do type inference in the 2D exterior calculus.
@@ -445,36 +445,37 @@ default_op1_type_inference_rules_2D = [
   (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm1, op = :⋆),
   (src_type = :infer, tgt_type = :Form2, replacement_type = :DualForm0, op = :⋆)]
 
-  default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, [
-    # Rules for ∧ where proj1 is unknown. ∧₁₁, ∧₂₁, ∧₁₂
-    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form2, replacement_type = :Form1, op = :∧),
-    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form3, replacement_type = :Form2, op = :∧),
-    (proj1_type = :infer, proj2_type = :Form2, res_type = :Form3, replacement_type = :Form1, op = :∧),
-    # Rules for ∧ where proj2 is unknown. ∧₁₁, ∧₂₁, ∧₁₂
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form1, op = :∧),
-    (proj1_type = :Form2, proj2_type = :infer, res_type = :Form3, replacement_type = :Form1, op = :∧),
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form3, replacement_type = :Form2, op = :∧),
-    # Rules for ∧ where res is unknown. ∧₁₁, ∧₂₁, ∧₁₂
-    (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form2, op = :∧),
-    (proj1_type = :Form2, proj2_type = :Form1, res_type = :infer, replacement_type = :Form3, op = :∧),
-    (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form3, op = :∧),
+# WARNING: I'm combining 1D and 2D rules directly here since it seems op2 rules
+# are metric-free. If for some reason we can't make this assumption, this needs to change
+default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, [
+  # Rules for ∧ where proj1 is unknown. ∧₁₁, ∧₂₀, ∧₀₂
+  (proj1_type = :infer, proj2_type = :Form1, res_type = :Form2, replacement_type = :Form1, op = :∧),
+  (proj1_type = :infer, proj2_type = :Form0, res_type = :Form2, replacement_type = :Form2, op = :∧),
+  (proj1_type = :infer, proj2_type = :Form2, res_type = :Form2, replacement_type = :Form0, op = :∧),
+  # Rules for ∧ where proj2 is unknown. ∧₁₁, ∧₂₀, ∧₀₂
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form1, op = :∧),
+  (proj1_type = :Form2, proj2_type = :infer, res_type = :Form2, replacement_type = :Form0, op = :∧),
+  (proj1_type = :Form0, proj2_type = :infer, res_type = :Form2, replacement_type = :Form2, op = :∧),
+  # Rules for ∧ where res is unknown. ∧₁₁, ∧₂₀, ∧₀₂
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form2, op = :∧),
+  (proj1_type = :Form2, proj2_type = :Form0, res_type = :infer, replacement_type = :Form2, op = :∧),
+  (proj1_type = :Form0, proj2_type = :Form2, res_type = :infer, replacement_type = :Form2, op = :∧),
 
-    # TODO: Overhaul since L apparently always needs a Form1 as it's first input
-    # Rules for L where proj1 is unknown. L₂
-    (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
-    # Rules for L where proj2 is unknown. L₂
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form2, op = :L),
-    # Rules for L where res is unknown. L₂
-    (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form2, op = :L),
+  # TODO: Overhaul since L apparently always needs a Form1 as it's first input
+  # Rules for L where proj1 is unknown. L₂
+  (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
+  # Rules for L where proj2 is unknown. L₂
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form2, op = :L),
+  # Rules for L where res is unknown. L₂
+  (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form2, op = :L),
 
-    # Rules for i where proj1 is unknown. i₁
-    (proj1_type = :infer, proj2_type = :Form2, res_type = :Form1, replacement_type = :Form1, op = :i),
-    # Rules for i where proj2 is unknown. i₁
-    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form2, op = :i),
-    # Rules for i where res is unknown. i₁
-    (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form1, op = :i)])
-
-    
+  # TODO: Similar issue for i, where i always needs a Form1 as it's first input
+  # Rules for i where proj1 is unknown. i₁
+  (proj1_type = :infer, proj2_type = :Form2, res_type = :Form1, replacement_type = :Form1, op = :i),
+  # Rules for i where proj2 is unknown. i₁
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form2, op = :i),
+  # Rules for i where res is unknown. i₁
+  (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form1, op = :i)])
 
 """
   function infer_summands_and_summations!(d::SummationDecapode)
@@ -602,10 +603,38 @@ infer_types!(d::SummationDecapode) =
   infer_types!(d, default_op1_type_inference_rules_2D, default_op2_type_inference_rules_2D)
 
 # TODO: You could write a method which auto-generates these rules given degree N.
+
+"""
+These are the default rules used to do function resolution in the 1D exterior calculus.
+"""
+default_op1_overloading_resolution_rules_1D = [
+  # Rules for d.
+  (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
+  (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
+  # Rules for ⋆.
+  (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :⋆),
+  (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :⋆),
+  (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
+  (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
+  # Rules for δ.
+  (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ)]
+
+default_op2_overloading_resolution_rules_1D = [
+  # Rules for ∧.
+  (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, resolved_name = :∧₀₀, op = :∧),
+  (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form1, resolved_name = :∧₁₀, op = :∧),
+  (proj1_type = :Form0, proj2_type = :Form1, res_type = :Form1, resolved_name = :∧₀₁, op = :∧),
+  # Rules for L.
+  (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form0, resolved_name = :L₀, op = :L),
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, resolved_name = :L₁, op = :L),
+  # Rules for i.
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form0, resolved_name = :i₁, op = :i)]
+
+
 """
 These are the default rules used to do function resolution in the 2D exterior calculus.
 """
-default_overloading_resolution_rules_2D = [
+default_op1_overloading_resolution_rules_2D = [
   # TODO: There are rules for op2s that must be written still.
   # Rules for d.
   (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
@@ -630,29 +659,12 @@ default_overloading_resolution_rules_2D = [
   (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ),
   (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :Δ)]
-
-"""
-These are the default rules used to do function resolution in the 1D exterior calculus.
-"""
-default_overloading_resolution_rules_1D = [
-  # TODO: There are rules for op2s that must be written still.
-  # Rules for d.
-  (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
-  (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
-  # Rules for ⋆.
-  (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :⋆),
-  (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :⋆),
-  (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
-  (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
-  # Rules for δ.
-  (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ)]
-
 """
   function resolve_overloads!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(:src_type, :tgt_type, :resolved_name, :op), NTuple{4, Symbol}}})
 
 Resolve function overloads based on types of src and tgt.
 """
-function resolve_overloads!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(:src_type, :tgt_type, :resolved_name, :op), NTuple{4, Symbol}}})
+function resolve_overloads!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(:src_type, :tgt_type, :resolved_name, :op), NTuple{4, Symbol}}}, op2_rules::Vector{NamedTuple{(:proj1_type, :proj2_type, :res_type, :resolved_name, :op), NTuple{5, Symbol}}})
   for op1_idx in parts(d, :Op1)
     src = d[:src][op1_idx]; tgt = d[:tgt][op1_idx]; op1 = d[:op1][op1_idx]
     src_type = d[:type][src]; tgt_type = d[:type][tgt]
@@ -663,11 +675,23 @@ function resolve_overloads!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(
       end
     end
   end
+
+  for op2_idx in parts(d, :Op2)
+    proj1 = d[:proj1][op2_idx]; proj2 = d[:proj2][op2_idx]; res = d[:res][op2_idx]; op2 = d[:op2][op2_idx]
+    proj1_type = d[:type][proj1]; proj2_type = d[:type][proj2]; res_type = d[:type][res]
+    for rule in op2_rules
+      if op2 == rule[:op] && proj1_type == rule[:proj1_type] && proj2_type == rule[:proj2_type] && res_type == rule[:res_type]
+        d[:op2][op2_idx] = rule[:resolved_name]
+        break
+      end
+    end
+  end
+
   d
 end
 
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 resolve_overloads!(d::SummationDecapode) =
-  resolve_overloads!(d, default_overloading_resolution_rules_2D)
+  resolve_overloads!(d, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_1D)
 

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -349,7 +349,7 @@ end
 """
 These are the default rules used to do type inference.
 """
-default_type_inference_rules = [
+default_type_inference_rules_2D = [
   # Rules for ∂ₜ where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
@@ -361,13 +361,27 @@ default_type_inference_rules = [
   # Rules for d where tgt is unknown.
   (src_type = :Form0, tgt_type = :infer, replacement_type = :Form1, op = :d),
   (src_type = :Form1, tgt_type = :infer, replacement_type = :Form2, op = :d),
-  (src_type = :DualForm2, tgt_type = :infer, replacement_type = :DualForm1, op = :d),
-  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :DualForm0, op = :d),
+  (src_type = :DualForm0, tgt_type = :infer, replacement_type = :DualForm1, op = :d),
+  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :DualForm2, op = :d),
   # Rules for d where src is unknown.
   (src_type = :infer, tgt_type = :Form2, replacement_type = :Form1, op = :d),
   (src_type = :infer, tgt_type = :Form1, replacement_type = :Form0, op = :d),
   (src_type = :infer, tgt_type = :DualForm0, replacement_type = :DualForm1, op = :d),
-  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :DualForm2, op = :d)]
+  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :DualForm2, op = :d),
+  # Rules for ⋆ where tgt is unknown.
+  (src_type = :Form0, tgt_type = :infer, replacement_type = :DualForm2, op = :⋆),
+  (src_type = :Form1, tgt_type = :infer, replacement_type = :DualForm1, op = :⋆),
+  (src_type = :Form2, tgt_type = :infer, replacement_type = :DualForm0, op = :⋆),
+  (src_type = :DualForm2, tgt_type = :infer, replacement_type = :Form0, op = :⋆),
+  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :Form1, op = :⋆),
+  (src_type = :DualForm0, tgt_type = :infer, replacement_type = :Form2, op = :⋆),
+  # Rules for ⋆ where src is unknown.
+  (src_type = :infer, tgt_type = :DualForm2, replacement_type = :Form0, op = :⋆),
+  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :Form1, op = :⋆),
+  (src_type = :infer, tgt_type = :DualForm0, replacement_type = :Form2, op = :⋆),
+  (src_type = :infer, tgt_type = :Form0, replacement_type = :DualForm2, op = :⋆),
+  (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm1, op = :⋆),
+  (src_type = :infer, tgt_type = :Form2, replacement_type = :DualForm0, op = :⋆)]
 
 """
   function infer_types_helper(d::SummationDecapode, src_type, tgt_type, op::Symbol)
@@ -412,5 +426,5 @@ function infer_types!(d::SummationDecapode, rules::Vector{NamedTuple{(:src_type,
 end
 
 infer_types!(d::SummationDecapode) =
-  infer_types!(d, default_type_inference_rules)
+  infer_types!(d, default_type_inference_rules_2D)
 

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -348,44 +348,6 @@ end
 
 # TODO: You could write a method which auto-generates these rules given degree N.
 """
-These are the default rules used to do type inference in the 2D exterior calculus.
-"""
-default_op1_type_inference_rules_2D = [
-  # TODO: There are rules for op2s that must be written still.
-  # Rules for ∂ₜ where tgt is unknown.
-  (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
-  (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
-  (src_type = :Form2, tgt_type = :infer, replacement_type = :Form2, op = :∂ₜ),
-  # Rules for ∂ₜ where src is unknown.
-  (src_type = :infer, tgt_type = :Form0, replacement_type = :Form0, op = :∂ₜ),
-  (src_type = :infer, tgt_type = :Form1, replacement_type = :Form1, op = :∂ₜ),
-  (src_type = :infer, tgt_type = :Form2, replacement_type = :Form2, op = :∂ₜ),
-  # Rules for d where tgt is unknown.
-  (src_type = :Form0, tgt_type = :infer, replacement_type = :Form1, op = :d),
-  (src_type = :Form1, tgt_type = :infer, replacement_type = :Form2, op = :d),
-  (src_type = :DualForm0, tgt_type = :infer, replacement_type = :DualForm1, op = :d),
-  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :DualForm2, op = :d),
-  # Rules for d where src is unknown.
-  (src_type = :infer, tgt_type = :Form2, replacement_type = :Form1, op = :d),
-  (src_type = :infer, tgt_type = :Form1, replacement_type = :Form0, op = :d),
-  (src_type = :infer, tgt_type = :DualForm0, replacement_type = :DualForm1, op = :d),
-  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :DualForm2, op = :d),
-  # Rules for ⋆ where tgt is unknown.
-  (src_type = :Form0, tgt_type = :infer, replacement_type = :DualForm2, op = :⋆),
-  (src_type = :Form1, tgt_type = :infer, replacement_type = :DualForm1, op = :⋆),
-  (src_type = :Form2, tgt_type = :infer, replacement_type = :DualForm0, op = :⋆),
-  (src_type = :DualForm2, tgt_type = :infer, replacement_type = :Form0, op = :⋆),
-  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :Form1, op = :⋆),
-  (src_type = :DualForm0, tgt_type = :infer, replacement_type = :Form2, op = :⋆),
-  # Rules for ⋆ where src is unknown.
-  (src_type = :infer, tgt_type = :DualForm2, replacement_type = :Form0, op = :⋆),
-  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :Form1, op = :⋆),
-  (src_type = :infer, tgt_type = :DualForm0, replacement_type = :Form2, op = :⋆),
-  (src_type = :infer, tgt_type = :Form0, replacement_type = :DualForm2, op = :⋆),
-  (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm1, op = :⋆),
-  (src_type = :infer, tgt_type = :Form2, replacement_type = :DualForm0, op = :⋆)]
-
-"""
 These are the default rules used to do type inference in the 1D exterior calculus.
 """
 default_op1_type_inference_rules_1D = [
@@ -438,13 +400,80 @@ default_op1_type_inference_rules_1D = [
     (proj1_type = :Form1, proj2_type = :Form0, res_type = :infer, replacement_type = :Form0, op = :L),
     (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form1, op = :L),   
 
-
     # Rules for i where proj1 is unknown. i₁
     (proj1_type = :infer, proj2_type = :Form1, res_type = :Form0, replacement_type = :Form1, op = :i),
     # Rules for i where proj2 is unknown. i₁
     (proj1_type = :Form1, proj2_type = :infer, res_type = :infer, replacement_type = :Form0, op = :i),
     # Rules for i where res is unknown. i₁
     (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form0, op = :i)]
+
+"""
+These are the default rules used to do type inference in the 2D exterior calculus.
+"""
+default_op1_type_inference_rules_2D = [
+  # TODO: There are rules for op2s that must be written still.
+  # Rules for ∂ₜ where tgt is unknown.
+  (src_type = :Form0, tgt_type = :infer, replacement_type = :Form0, op = :∂ₜ),
+  (src_type = :Form1, tgt_type = :infer, replacement_type = :Form1, op = :∂ₜ),
+  (src_type = :Form2, tgt_type = :infer, replacement_type = :Form2, op = :∂ₜ),
+  # Rules for ∂ₜ where src is unknown.
+  (src_type = :infer, tgt_type = :Form0, replacement_type = :Form0, op = :∂ₜ),
+  (src_type = :infer, tgt_type = :Form1, replacement_type = :Form1, op = :∂ₜ),
+  (src_type = :infer, tgt_type = :Form2, replacement_type = :Form2, op = :∂ₜ),
+  # Rules for d where tgt is unknown.
+  (src_type = :Form0, tgt_type = :infer, replacement_type = :Form1, op = :d),
+  (src_type = :Form1, tgt_type = :infer, replacement_type = :Form2, op = :d),
+  (src_type = :DualForm0, tgt_type = :infer, replacement_type = :DualForm1, op = :d),
+  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :DualForm2, op = :d),
+  # Rules for d where src is unknown.
+  (src_type = :infer, tgt_type = :Form2, replacement_type = :Form1, op = :d),
+  (src_type = :infer, tgt_type = :Form1, replacement_type = :Form0, op = :d),
+  (src_type = :infer, tgt_type = :DualForm0, replacement_type = :DualForm1, op = :d),
+  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :DualForm2, op = :d),
+  # Rules for ⋆ where tgt is unknown.
+  (src_type = :Form0, tgt_type = :infer, replacement_type = :DualForm2, op = :⋆),
+  (src_type = :Form1, tgt_type = :infer, replacement_type = :DualForm1, op = :⋆),
+  (src_type = :Form2, tgt_type = :infer, replacement_type = :DualForm0, op = :⋆),
+  (src_type = :DualForm2, tgt_type = :infer, replacement_type = :Form0, op = :⋆),
+  (src_type = :DualForm1, tgt_type = :infer, replacement_type = :Form1, op = :⋆),
+  (src_type = :DualForm0, tgt_type = :infer, replacement_type = :Form2, op = :⋆),
+  # Rules for ⋆ where src is unknown.
+  (src_type = :infer, tgt_type = :DualForm2, replacement_type = :Form0, op = :⋆),
+  (src_type = :infer, tgt_type = :DualForm1, replacement_type = :Form1, op = :⋆),
+  (src_type = :infer, tgt_type = :DualForm0, replacement_type = :Form2, op = :⋆),
+  (src_type = :infer, tgt_type = :Form0, replacement_type = :DualForm2, op = :⋆),
+  (src_type = :infer, tgt_type = :Form1, replacement_type = :DualForm1, op = :⋆),
+  (src_type = :infer, tgt_type = :Form2, replacement_type = :DualForm0, op = :⋆)]
+
+  default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, [
+    # Rules for ∧ where proj1 is unknown. ∧₁₁, ∧₂₁, ∧₁₂
+    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form2, replacement_type = :Form1, op = :∧),
+    (proj1_type = :infer, proj2_type = :Form1, res_type = :Form3, replacement_type = :Form2, op = :∧),
+    (proj1_type = :infer, proj2_type = :Form2, res_type = :Form3, replacement_type = :Form1, op = :∧),
+    # Rules for ∧ where proj2 is unknown. ∧₁₁, ∧₂₁, ∧₁₂
+    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form1, op = :∧),
+    (proj1_type = :Form2, proj2_type = :infer, res_type = :Form3, replacement_type = :Form1, op = :∧),
+    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form3, replacement_type = :Form2, op = :∧),
+    # Rules for ∧ where res is unknown. ∧₁₁, ∧₂₁, ∧₁₂
+    (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form2, op = :∧),
+    (proj1_type = :Form2, proj2_type = :Form1, res_type = :infer, replacement_type = :Form3, op = :∧),
+    (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form3, op = :∧),
+
+    # TODO: Overhaul since L apparently always needs a Form1 as it's first input
+    # Rules for L where proj1 is unknown. L₂
+    (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
+    # Rules for L where proj2 is unknown. L₂
+    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form2, op = :L),
+    # Rules for L where res is unknown. L₂
+    (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form2, op = :L),
+
+    # Rules for i where proj1 is unknown. i₁
+    (proj1_type = :infer, proj2_type = :Form2, res_type = :Form1, replacement_type = :Form1, op = :i),
+    # Rules for i where proj2 is unknown. i₁
+    (proj1_type = :Form1, proj2_type = :infer, res_type = :Form1, replacement_type = :Form2, op = :i),
+    # Rules for i where res is unknown. i₁
+    (proj1_type = :Form1, proj2_type = :Form2, res_type = :infer, replacement_type = :Form1, op = :i)])
+
     
 
 """
@@ -570,7 +599,7 @@ end
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 infer_types!(d::SummationDecapode) =
-  infer_types!(d, default_op1_type_inference_rules_2D, default_op2_type_inference_rules_1D)
+  infer_types!(d, default_op1_type_inference_rules_2D, default_op2_type_inference_rules_2D)
 
 # TODO: You could write a method which auto-generates these rules given degree N.
 """

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -124,12 +124,11 @@ end
 These are the default rewrite rules used to do type inference.
 """
 default_type_inference_rules = [
+  # The tgt of ∂ₜ is of the same type as its src.
   begin
     L = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2
-      TVar = 1
-      Op1 = 1
-      
+      Var = 2; TVar = 1; Op1 = 1
+
       type = [ARVar(:src_form), :infer]
       name = [ARVar(:src_name), ARVar(:tgt_name)]
       incl = [2]
@@ -139,15 +138,12 @@ default_type_inference_rules = [
     end
     I = @acset SummationDecapode{Any, Any, Any} begin
       Var = 1
-      
       type = [ARVar(:src_form)]
       name = [ARVar(:src_name)]
     end
     R = @acset SummationDecapode{Any, Any, Any} begin
-      Var = 2
-      TVar = 1
-      Op1 = 1
-      
+      Var = 2; TVar = 1; Op1 = 1
+
       type = [ARVar(:src_form), ARVar(:src_form)]
       name = [ARVar(:src_name), ARVar(:tgt_name)]
       incl = [2]
@@ -158,9 +154,160 @@ default_type_inference_rules = [
     hil = AlgebraicRewriting.homomorphism(I, L)
     hir = AlgebraicRewriting.homomorphism(I, R)
     Rule(hil, hir)
+  end,
+  # The src of ∂ₜ is of the same type as its tgt.
+  begin
+    L = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; TVar = 1; Op1 = 1
+
+      type = [:infer, ARVar(:tgt_form)]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      incl = [2]
+      src = [1]
+      tgt = [2]
+      op1 = [:∂ₜ]
+    end
+    I = @acset SummationDecapode{Any, Any, Any} begin
+      #Var = 1
+      #type = [ARVar(:tgt_form)]
+      #name = [ARVar(:tgt_name)]
+      Var = 1; TVar = 1
+      type = [ARVar(:tgt_form)]
+      name = [ARVar(:tgt_name)]
+      incl = [1]
+    end
+    R = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; TVar = 1; Op1 = 1
+
+      type = [ARVar(:tgt_form), ARVar(:tgt_form)]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      incl = [2]
+      src = [1]
+      tgt = [2]
+      op1 = [:∂ₜ]
+    end
+    hil = AlgebraicRewriting.homomorphism(I, L)
+    hir = AlgebraicRewriting.homomorphism(I, R)
+    Rule(hil, hir)
+  end,
+  # The tgt of d of a Form0 is of the type Form1.
+  begin
+    L = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:Form0, :infer]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    I = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 1
+      type = [:Form0]
+      name = [ARVar(:src_name)]
+    end
+    R = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:Form0, :Form1]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    hil = AlgebraicRewriting.homomorphism(I, L)
+    hir = AlgebraicRewriting.homomorphism(I, R)
+    Rule(hil, hir)
+  end,
+  # The tgt of d of a Form1 is of the type Form2.
+  begin
+    L = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:Form1, :infer]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    I = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 1
+      type = [:Form1]
+      name = [ARVar(:src_name)]
+    end
+    R = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:Form1, :Form2]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    hil = AlgebraicRewriting.homomorphism(I, L)
+    hir = AlgebraicRewriting.homomorphism(I, R)
+    Rule(hil, hir)
+  end,
+  # The src of d of a Form1 is of the type Form0.
+  begin
+    L = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:infer, :Form1]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    I = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 1
+      type = [:Form1]
+      name = [ARVar(:tgt_name)]
+    end
+    R = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:Form0, :Form1]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    hil = AlgebraicRewriting.homomorphism(I, L)
+    hir = AlgebraicRewriting.homomorphism(I, R)
+    Rule(hil, hir)
+  end,
+  # The src of d of a Form2 is of the type Form1.
+  begin
+    L = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:infer, :Form2]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    I = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 1
+      type = [:Form2]
+      name = [ARVar(:tgt_name)]
+    end
+    R = @acset SummationDecapode{Any, Any, Any} begin
+      Var = 2; Op1 = 1
+
+      type = [:Form1, :Form2]
+      name = [ARVar(:src_name), ARVar(:tgt_name)]
+      src = [1]
+      tgt = [2]
+      op1 = [:d]
+    end
+    hil = AlgebraicRewriting.homomorphism(I, L)
+    hir = AlgebraicRewriting.homomorphism(I, R)
+    Rule(hil, hir)
   end]
 
-function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}})
+function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}}; kw...)
   # Step 1: Convert to {Any,Any,Any} so we can use AlgebraicRewriting's Var.
   #d′ = migrate(SummationDecapode{Any, Any, Any}, d,
   #  Dict(:Var => :Var, :TVar => :TVar, :Op1 => :Op1, :Op2 => :Op2, :Σ => :Σ, :Summand => :Summand, :Type => :Type, :Operator => :Operator, :Name => :Name),
@@ -180,7 +327,7 @@ function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}})
   ar_step = ListSchedule(seq)
   end_condition(prev, curr) = :infer ∉ curr[:type]
   overall = WhileSchedule(ar_step, :main, end_condition)
-  trajectory = apply_schedule(overall, G=d′)
+  trajectory = apply_schedule(overall; G=d′, kw...)
   res = last(trajectory).G
   # Step 3: Convert back to {Any,Any,Symbol}.
   #migrate(SummationDecapode{Any, Any, Symbol}, res
@@ -195,6 +342,6 @@ function infer_types(d::SummationDecapode, rules::Vector{Rule{:DPO}})
       Dict(SchSummationDecapode.generators.Attr .=> SchSummationDecapode.generators.Attr)))
 end
 
-infer_types(d::SummationDecapode) =
-  infer_types(d, default_type_inference_rules)
+infer_types(d::SummationDecapode; kw...) =
+  infer_types(d, default_type_inference_rules; kw...)
 

--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -403,7 +403,7 @@ default_op2_type_inference_rules_1D = [
   # Rules for i where proj1 is unknown. i₁
   (proj1_type = :infer, proj2_type = :Form1, res_type = :Form0, replacement_type = :Form1, op = :i),
   # Rules for i where proj2 is unknown. i₁
-  (proj1_type = :Form1, proj2_type = :infer, res_type = :infer, replacement_type = :Form0, op = :i),
+  (proj1_type = :Form1, proj2_type = :infer, res_type = :Form0, replacement_type = :Form1, op = :i),
   # Rules for i where res is unknown. i₁
   (proj1_type = :Form1, proj2_type = :Form1, res_type = :infer, replacement_type = :Form0, op = :i)]
 
@@ -463,7 +463,7 @@ default_op2_type_inference_rules_2D = vcat(default_op2_type_inference_rules_1D, 
 
   # TODO: Overhaul since L apparently always needs a Form1 as it's first input
   # Rules for L where proj1 is unknown. L₂
-  (proj1_type = :infer, proj2_type = :Form0, res_type = :Form0, replacement_type = :Form1, op = :L),
+  (proj1_type = :infer, proj2_type = :Form2, res_type = :Form2, replacement_type = :Form1, op = :L),
   # Rules for L where proj2 is unknown. L₂
   (proj1_type = :Form1, proj2_type = :infer, res_type = :Form2, replacement_type = :Form2, op = :L),
   # Rules for L where res is unknown. L₂
@@ -708,3 +708,4 @@ end
 resolve_overloads!(d::SummationDecapode) =
   resolve_overloads!(d, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_2D)
 
++

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!, default_op1_type_inference_rules_1D, default_op1_type_inference_rules_2D, default_op2_type_inference_rules_1D, default_op2_type_inference_rules_2D, default_op1_overloading_resolution_rules_1D, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_1D, default_op2_overloading_resolution_rules_2D,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!, op1_inf_rules_1D, op2_inf_rules_1D, op1_inf_rules_2D, op2_inf_rules_2D, op1_res_rules_1D, op2_res_rules_1D, op1_res_rules_2D, op2_res_rules_2D,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!, default_op1_type_inference_rules_1D, default_op1_type_inference_rules_2D, default_op2_type_inference_rules_1D, default_op2_type_inference_rules_2D, default_op1_overloading_resolution_rules_1D, default_op1_overloading_resolution_rules_2D, default_op2_overloading_resolution_rules_1D, default_op2_overloading_resolution_rules_2D,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, expand_compositions!, infer_types!, resolve_overloads!,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/src/Decapodes2/decapodes.jl
+++ b/src/Decapodes2/decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, expand_compositions!, infer_types!, resolve_overloads!,
   Term, Var, Judge, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, closest_point, flat_op,

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -339,3 +339,77 @@ end
 
 end
 
+@testset "Overloading Resolution" begin
+  # d overloading is resolved.
+  Test1 = quote
+    A::Form0{X}
+    B::Form1{X}
+    C::Form2{X}
+    D::DualForm0{X}
+    E::DualForm1{X}
+    F::DualForm2{X}
+    B == d(A)
+    C == d(B)
+    E == d(D)
+    F == d(E)
+  end
+  t1 = SummationDecapode(parse_decapode(Test1))
+  resolve_overloads!(t1)
+
+  op1s_1 = t1[:op1]
+  op1s_expected_1 = [:d₀ , :d₁, :dual_d₀, :dual_d₁]
+  @test op1s_1 == op1s_expected_1
+  
+  # ⋆ overloading is resolved.
+  Test2 = quote
+    C::Form0{X}
+    D::DualForm2{X}
+    E::Form1{X}
+    F::DualForm1{X}
+    G::Form2{X}
+    H::DualForm0{X}
+    D == ⋆(C)
+    C == ⋆(D)
+    E == ⋆(F)
+    F == ⋆(E)
+    G == ⋆(H)
+    H == ⋆(G)
+  end
+  t2 = SummationDecapode(parse_decapode(Test2))
+  resolve_overloads!(t2)
+
+  op1s_2 = t2[:op1]
+  # Note: The Op1 table of the decapode created does not have the functions
+  # listed in the order in which they appear in Test2.
+  op1s_expected_2 = [:⋆₀ , :⋆₀⁻¹ , :⋆₁⁻¹ , :⋆₁ , :⋆₂⁻¹ , :⋆₂]
+  @test op1s_2 == op1s_expected_2
+  
+  # All overloading on the de Rahm complex is resolved.
+  Test3 = quote
+    A::Form0{X}
+    B::Form1{X}
+    C::Form2{X}
+    D::DualForm0{X}
+    E::DualForm1{X}
+    F::DualForm2{X}
+    B == d(A)
+    C == d(B)
+    E == d(D)
+    F == d(E)
+    F == ⋆(A)
+    A == ⋆(F)
+    E == ⋆(B)
+    B == ⋆(E)
+    D == ⋆(C)
+    C == ⋆(D)
+  end
+  t3 = SummationDecapode(parse_decapode(Test3))
+  resolve_overloads!(t3)
+
+  op1s_3 = t3[:op1]
+  # Note: The Op1 table of the decapode created does not have the functions
+  # listed in the order in which they appear in Test2.
+  op1s_expected_3 = [:d₀ , :d₁, :dual_d₀, :dual_d₁, :⋆₀ , :⋆₀⁻¹ , :⋆₁ , :⋆₁⁻¹ , :⋆₂ , :⋆₂⁻¹]
+  @test op1s_3 == op1s_expected_3
+end
+

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -214,6 +214,11 @@ end
 end
 
 @testset "Type Inference" begin
+  
+  function get_name_type_pair(d::SummationDecapode)
+    Set(zip(d[:name], d[:type]))
+  end
+
   # The type of the tgt of ∂ₜ is inferred.
   Test1 = quote
     C::Form0{X}
@@ -446,11 +451,6 @@ end
   names_types_expected_12 = Set([(:A, :Form1), (:B, :Form1), (:C, :Form0)])
   @test issetequal(names_types_12, names_types_expected_12)
 end
-
-function get_name_type_pair(d::SummationDecapode)
-  Set(zip(d[:name], d[:type]))
-end
-
 
 @testset "Overloading Resolution" begin
   # d overloading is resolved.

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -393,10 +393,9 @@ end
 
   names_types_9 = Set(zip(t9[:name], t9[:type]))
   names_types_expected_9 = Set([
-    (:A, :Form0),     (:•1, :Form1),     (:•2, :Form2),
-    (:B, :DualForm2), (:•4, :DualForm1), (:•3, :DualForm0)])
+    (:A, :Form0),     (Symbol('•', 1), :Form1),     (Symbol('•', 2), :Form2),
+    (:B, :DualForm2), (Symbol('•', 4), :DualForm1), (Symbol('•', 3), :DualForm0)])
   @test issetequal(names_types_9, names_types_expected_9)
-  @test op1s_9 == op1s_expected_9
 end
 
 @testset "Overloading Resolution" begin

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -396,7 +396,61 @@ end
     (:A, :Form0),     (Symbol("•_1_", 1), :Form1),     (Symbol("•_1_", 2), :Form2),
     (:B, :DualForm2), (Symbol("•_1_", 4), :DualForm1), (Symbol("•_1_", 3), :DualForm0)])
   @test issetequal(names_types_9, names_types_expected_9)
+
+  # Basic op2 inference using ∧
+  Test10 = quote
+    (A, B)::Form0{X}
+    C::infer{X}
+
+    D::Form0{X}
+    E::Form1{X}
+    (F, H)::infer{X}
+    C == ∧(A, B)
+    F == ∧(D, E)
+    H == ∧(E, D)
+  end
+  t10 = SummationDecapode(parse_decapode(Test10))
+  infer_types!(t10)
+
+  names_types_10 = get_name_type_pair(t10)
+  names_types_expected_10 = Set([(:F, :Form1), (:B, :Form0), (:C, :Form0), (:H, :Form1), (:A, :Form0), (:E, :Form1), (:D, :Form0)])
+  @test issetequal(names_types_10, names_types_expected_10)
+
+  # Basic op2 inference using L
+  Test11 = quote
+    (A, E)::Form1{X}
+    B::Form0{X}
+    (C, D)::infer{X}
+
+    C == L(A, B)
+    D == L(A, E)
+  end
+  t11 = SummationDecapode(parse_decapode(Test11))
+  infer_types!(t11)
+
+  names_types_11 = get_name_type_pair(t11)
+  names_types_expected_11 = Set([(:A, :Form1), (:B, :Form0), (:C, :Form0), (:E, :Form1), (:D, :Form1)])
+  @test issetequal(names_types_11, names_types_expected_11)
+
+  # Basic op2 inference using i
+  Test12 = quote
+    (A, B)::Form1{X}
+    C::infer{X}
+
+    C == i(A, B)
+  end
+  t12 = SummationDecapode(parse_decapode(Test12))
+  infer_types!(t12)
+
+  names_types_12 = get_name_type_pair(t12)
+  names_types_expected_12 = Set([(:A, :Form1), (:B, :Form1), (:C, :Form0)])
+  @test issetequal(names_types_12, names_types_expected_12)
 end
+
+function get_name_type_pair(d::SummationDecapode)
+  Set(zip(d[:name], d[:type]))
+end
+
 
 @testset "Overloading Resolution" begin
   # d overloading is resolved.

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -381,6 +381,22 @@ end
   infer_types!(decapode_to_infer)
   @test decapode_to_infer == decapode_expected
 
+  # Inference can happen "through" composed ops.
+  Test9 = quote
+    A::Form0{X}
+    B::infer{X}
+    B == ∘(d,d,⋆,d,d)(A)
+  end
+  t9 = SummationDecapode(parse_decapode(Test9))
+  expand_compositions!(t9)
+  infer_types!(t9)
+
+  names_types_9 = Set(zip(t9[:name], t9[:type]))
+  names_types_expected_9 = Set([
+    (:A, :Form0),     (:•1, :Form1),     (:•2, :Form2),
+    (:B, :DualForm2), (:•4, :DualForm1), (:•3, :DualForm0)])
+  @test issetequal(names_types_9, names_types_expected_9)
+  @test op1s_9 == op1s_expected_9
 end
 
 @testset "Overloading Resolution" begin

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -109,7 +109,6 @@ end
 
   recExpr = parse_decapode(Recursion)
   rdp = SummationDecapode(recExpr)
-  show(rdp)
 
   @test nparts(rdp, :Var) == 9
   @test nparts(rdp, :TVar) == 1
@@ -726,8 +725,8 @@ end
   (proj1_type = :Form1, proj2_type = :Constant, res_type = :infer, replacement_type = :Form1, op = :*),
   (proj1_type = :Form2, proj2_type = :Constant, res_type = :infer, replacement_type = :Form2, op = :*)]
 
-  infer_types!(HeatXfer, vcat(bespoke_op1_inf_rules, default_op1_type_inference_rules_2D),
-    vcat(bespoke_op2_inf_rules, default_op2_type_inference_rules_2D))
+  infer_types!(HeatXfer, vcat(bespoke_op1_inf_rules, op1_inf_rules_2D),
+    vcat(bespoke_op2_inf_rules, op2_inf_rules_2D))
 
   names_types_hx = Set(zip(HeatXfer[:name], HeatXfer[:type]))
 
@@ -789,8 +788,8 @@ end
   (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, resolved_name = :L₀, op = :L),
   (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, resolved_name = :L₁′, op = :L)]
 
-  resolve_overloads!(HeatXfer, default_op1_overloading_resolution_rules_2D,
-    vcat(bespoke_op2_res_rules, default_op2_overloading_resolution_rules_2D))
+  resolve_overloads!(HeatXfer, op1_res_rules_2D,
+    vcat(bespoke_op2_res_rules, op2_res_rules_2D))
 
   op1s_hx = HeatXfer[:op1]
   op1s_expected_hx = [:d₀, :⋆₁, :dual_d₁, :⋆₀⁻¹, :avg, :R₀, :⋆₀, :⋆₀⁻¹, :neg, :∂ₜ, :avg, :neg, :avg, :Δ₁, :δ₁, :d₀, :d₀, :avg, :d₀, :neg, :avg, :∂ₜ, :⋆₀, :⋆₀⁻¹, :neg, :∂ₜ]

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -288,5 +288,24 @@ end
   names_types_expected_5 = Set([(:C, :Form0), (:D, :Form1)])
   @test issetequal(names_types_5, names_types_expected_5)
 
+  # The type of the src of d is inferred.
+  Test6 = quote
+    A::Form0{X}
+    (B,C,D,E,F)::infer{X}
+    B == d(A)
+    C == d(B)
+    D == ⋆(C)
+    E == d(D)
+    F == d(E)
+  end
+  t6 = SummationDecapode(parse_decapode(Test6))
+  infer_types!(t6)
+
+  names_types_6 = Set(zip(t6[:name], t6[:type]))
+  names_types_expected_6 = Set([
+    (:A, :Form0),     (:B, :Form1),     (:C, :Form2),
+    (:F, :DualForm2), (:E, :DualForm1), (:D, :DualForm0)])
+  @test issetequal(names_types_6, names_types_expected_6)
+
 end
 

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -220,10 +220,10 @@ end
     ∂ₜ(C) == C
   end
   t1 = SummationDecapode(parse_decapode(Test1))
-  t1_inferred = infer_types(t1)
+  infer_types!(t1)
 
   # We use set equality because we do not care about the order of the Var table.
-  names_types_1 = Set(zip(t1_inferred[:name], t1_inferred[:type]))
+  names_types_1 = Set(zip(t1[:name], t1[:type]))
   names_types_expected_1 = Set([(:Ċ, :Form0), (:C, :Form0)])
   @test issetequal(names_types_1, names_types_expected_1)
 
@@ -234,9 +234,9 @@ end
   end
   t2 = SummationDecapode(parse_decapode(Test2))
   t2[:type][only(incident(t2, :Ċ, :name))] = :Form0
-  t2_inferred = infer_types(t2)
+  infer_types!(t2)
 
-  names_types_2 = Set(zip(t2_inferred[:name], t2_inferred[:type]))
+  names_types_2 = Set(zip(t2[:name], t2[:type]))
   names_types_expected_2 = Set([(:Ċ, :Form0), (:C, :Form0)])
   @test issetequal(names_types_2, names_types_expected_2)
 
@@ -252,25 +252,41 @@ end
     E == d(D)
   end
   t3 = SummationDecapode(parse_decapode(Test3))
-  #t3_inferred = infer_types(t3)
-  t3_inferred = infer_types(t3, verbose=true)
+  #t3_inferred = infer_types!(t3)
+  infer_types!(t3)
 
-  names_types_3 = Set(zip(t3_inferred[:name], t3_inferred[:type]))
+  names_types_3 = Set(zip(t3[:name], t3[:type]))
   names_types_expected_3 = Set([(:C, :Form0), (:D, :Form1), (:E, :Form2)])
   @test issetequal(names_types_3, names_types_expected_3)
 
-  # The type of the src of d is inferred.
+  # The type of the src and tgt of d is inferred.
   Test4 = quote
+    C::infer{X}
+    D::Form1{X}
+    E::infer{X}
+    D == d(C)
+    E == d(D)
+  end
+  t4 = SummationDecapode(parse_decapode(Test4))
+  #t4_inferred = infer_types!(t4)
+  infer_types!(t4)
+
+  names_types_4 = Set(zip(t4[:name], t4[:type]))
+  names_types_expected_4 = Set([(:C, :Form0), (:D, :Form1), (:E, :Form2)])
+  @test issetequal(names_types_4, names_types_expected_4)
+
+  # The type of the src of d is inferred.
+  Test5 = quote
     C::infer{X}
     D::Form1{X}
     D == d(C)
   end
-  t4 = SummationDecapode(parse_decapode(Test4))
-  t4_inferred = infer_types(t4)
+  t5 = SummationDecapode(parse_decapode(Test5))
+  infer_types!(t5)
 
-  names_types_4 = Set(zip(t4_inferred[:name], t4_inferred[:type]))
-  names_types_expected_4 = Set([(:C, :Form0), (:D, :Form1)])
-  @test issetequal(names_types_4, names_types_expected_4)
+  names_types_5 = Set(zip(t5[:name], t5[:type]))
+  names_types_expected_5 = Set([(:C, :Form0), (:D, :Form1)])
+  @test issetequal(names_types_5, names_types_expected_5)
 
 end
 

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -307,5 +307,35 @@ end
     (:F, :DualForm2), (:E, :DualForm1), (:D, :DualForm0)])
   @test issetequal(names_types_6, names_types_expected_6)
 
+  function makeInferPathDeca(log_cycles; infer_path = false)
+    cycles = 2 ^ log_cycles
+    num_nodes = 6 * cycles
+    num_ops = num_nodes - 1
+
+    if(infer_path)
+      type_arr = vcat(:Form0, fill(:infer, num_nodes - 1))
+    else
+      type_arr = repeat([:Form0, :Form1, :Form2, :DualForm0, :DualForm1, :DualForm2], cycles)
+    end
+
+    InferPathTest = @acset SummationDecapode{Any, Any, Symbol} begin
+      Var = num_nodes
+      type = type_arr
+      name = map(x -> Symbol("•$x"), 1:num_nodes)
+
+      Op1 = num_ops
+      src = 1:num_ops
+      tgt = 2:num_ops + 1
+      op1 = repeat([:d, :d, :⋆, :d, :d, :⋆], cycles)[1:num_ops]
+    end
+  end
+  # log_cycles > 6 starts to be slow
+  log_cycles = 3
+
+  decapode_to_infer = makeInferPathDeca(log_cycles, infer_path = true)
+  decapode_expected = makeInferPathDeca(log_cycles)
+  infer_types!(decapode_to_infer)
+  @test decapode_to_infer == decapode_expected
+
 end
 

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -388,13 +388,13 @@ end
     B == ∘(d,d,⋆,d,d)(A)
   end
   t9 = SummationDecapode(parse_decapode(Test9))
-  expand_compositions!(t9)
+  t9 = expand_operators(t9)
   infer_types!(t9)
 
   names_types_9 = Set(zip(t9[:name], t9[:type]))
   names_types_expected_9 = Set([
-    (:A, :Form0),     (Symbol('•', 1), :Form1),     (Symbol('•', 2), :Form2),
-    (:B, :DualForm2), (Symbol('•', 4), :DualForm1), (Symbol('•', 3), :DualForm0)])
+    (:A, :Form0),     (Symbol("•_1_", 1), :Form1),     (Symbol("•_1_", 2), :Form2),
+    (:B, :DualForm2), (Symbol("•_1_", 4), :DualForm1), (Symbol("•_1_", 3), :DualForm0)])
   @test issetequal(names_types_9, names_types_expected_9)
 end
 

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -307,6 +307,50 @@ end
     (:F, :DualForm2), (:E, :DualForm1), (:D, :DualForm0)])
   @test issetequal(names_types_6, names_types_expected_6)
 
+  # The type of a summand is inferred.
+  Test7 = quote
+    A::Form0{X}
+    (B,C,D,E,F)::infer{X}
+    A == B+C+D+E+F
+  end
+  t7 = SummationDecapode(parse_decapode(Test7))
+  infer_types!(t7)
+
+  types_7 = Set(t7[:type])
+  types_expected_7 = Set([:Form0])
+  @test issetequal(types_7, types_expected_7)
+
+  # The type of a sum is inferred.
+  Test8 = quote
+    B::Form0{X}
+    (A,C,D,E,F)::infer{X}
+    A == B+C+D+E+F
+  end
+  t8 = SummationDecapode(parse_decapode(Test8))
+  infer_types!(t8)
+
+  types_8 = Set(t8[:type])
+  types_expected_8 = Set([:Form0])
+  @test issetequal(types_8, types_expected_8)
+
+  # Type inference of op1 propagates through sums.
+  Test8 = quote
+    Γ::Form0{X}
+    (A,B,C,D,E,F,Θ)::infer{X}
+    B == d(Γ)
+    A == B+C+D+E+F
+    Θ == d(A)
+  end
+  t8 = SummationDecapode(parse_decapode(Test8))
+  infer_types!(t8)
+
+  names_types_8 = Set(zip(t8[:name], t8[:type]))
+  names_types_expected_8 = Set([
+    (:Γ, :Form0),
+    (:A, :Form1), (:B, :Form1), (:C, :Form1), (:D, :Form1), (:E, :Form1), (:F, :Form1),
+    (:Θ, :Form2)])
+  @test issetequal(names_types_8, names_types_expected_8)
+
   function makeInferPathDeca(log_cycles; infer_path = false)
     cycles = 2 ^ log_cycles
     num_nodes = 6 * cycles

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -583,15 +583,15 @@ end
 
   Test4 = quote
     (A, C, F, H)::Form0{X}
-    (B, B₂, D, E, G)::Form1{X}
+    (B, D, E, G)::Form1{X}
 
 
     C == ∧(A, A)
     D == ∧(A, B)
     E == ∧(B, A)
     F == L(B, A)
-    G == L(B, B₂)
-    H == i(B, B₂)
+    G == L(B, B)
+    H == i(B, B)
   end
   t4 = SummationDecapode(parse_decapode(Test4))
   resolve_overloads!(t4)
@@ -599,6 +599,22 @@ end
   op2s_expected_4 = [:∧₀₀ , :∧₀₁, :∧₁₀, :L₀, :L₁, :i₁]
   @test op2s_4 == op2s_expected_4
 
+  Test5 = quote
+    A::Form0{X}
+    (B, H)::Form1{X}
+    (C, D, E, F, G)::Form2{X}
+
+    D == ∧(B, B)
+    E == ∧(A, C)
+    F == ∧(C, A)
+    G == L(B, C)
+    H == i(B, C)
+  end
+  t5 = SummationDecapode(parse_decapode(Test5))
+  resolve_overloads!(t5)
+  op2s_5 = t5[:op2]
+  op2s_expected_5 = [:∧₁₁, :∧₀₂, :∧₂₀, :L₂, :i₂]
+  @test op2s_5 == op2s_expected_5
 end
 
 @testset "Type Inference and Overloading Resolution Integration" begin

--- a/test/Decapodes2/diag2dwd.jl
+++ b/test/Decapodes2/diag2dwd.jl
@@ -213,3 +213,19 @@ end
     @test nparts(advdiffdp, :Summand) == 2
 end
 
+@testset "Type Inference" begin
+  Test1 = quote
+    C::Form0{X}
+    ∂ₜ(C) == C
+  end
+  t1 = SummationDecapode(parse_decapode(Test1))
+
+  t1_inferred = infer_types(t1)
+
+  # We use set equality because we do not care about the order of the Var table.
+  names_types = Set(zip(t1_inferred[:name], t1_inferred[:type]))
+  names_types_expected = Set([(:Ċ, :Form0), (:C, :Form0)])
+  @test issetequal(names_types, names_types_expected)
+
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,6 @@ end
   include("Examples.jl")
 end
 
-@testset "Decapodes2" begin
+@testset verbose = true "Decapodes2" begin
   include(joinpath(@__DIR__, "Decapodes2", "runtests.jl"))
 end


### PR DESCRIPTION
Currently, Decapodes compilation does not include any type inference stage, nor does it support function overloading, except for the `+` operator.

Type inference is useful for the reasons it is useful in programming. Further, it will let us support in the future the ability to use variables without declaring them.

Function overloading is useful for the reasons it is useful in programming. Further, it lets users write their Exterior Calculus equations in the format they appear in scientific papers, i.e. without subscripting their operators like `d` and hodge star with the type of the argument.

Both these techniques are being implemented in this pull request because they can both be performed using the same rewrite rules strategy via `AlgebraicRewriting.jl`.