### PR TITLE
Update for Catlab v0.14.14

### DIFF
--- a/src/Decapodes2/decapodeacset.jl
+++ b/src/Decapodes2/decapodeacset.jl
@@ -37,7 +37,7 @@ add new variable names to all the variables that don't have names.
 function fill_names!(d::AbstractNamedDecapode)
     bulletcount = 1
     for i in parts(d, :Var)
-        if !isassigned(d[:,:name],i)
+        if !isassigned(d[:,:name],i) || isnothing(d[i, :name])
             d[i,:name] = Symbol("•$bulletcount")
             bulletcount += 1
         end


### PR DESCRIPTION
Checks for uninitialized attributes in ACSets now must consider whether the given attribute is `nothing`.

This pull request checks for this condition when initializing intermediate variable names.