### PR TITLE
Import compile from Catlab.Programs

### DIFF
--- a/src/Decapodes2/simulation.jl
+++ b/src/Decapodes2/simulation.jl
@@ -3,6 +3,8 @@ using MultiScaleArrays
 using OrdinaryDiffEq
 using GeometryBasics
 
+import Catlab.Programs.GenerateJuliaPrograms: compile
+
 struct VectorForm{B} <: AbstractMultiScaleArrayLeaf{B}
     values::Vector{B}
 end


### PR DESCRIPTION
Using `Catlab.Programs` can sometimes cause naming conflicts, because `Catlab.Programs.GenerateJuliaPrograms` and this project both define a function `compile`.

Renaming `compile` to `compile_decapode` was considered, but since these functions are similar, it seems best to `import Catlab.Programs.GenerateJuliaPrograms: compile`.