### PR TITLE
Do not convert edge labels that are already Strings

### DIFF
--- a/src/Decapodes2/visualization.jl
+++ b/src/Decapodes2/visualization.jl
@@ -32,6 +32,8 @@ to_graphviz(GraphvizGraphs.to_graphviz_property_graph(F; directed, kw...))
 
 decapode_edge_label(s::Symbol) = String(s)
 decapode_edge_label(s::Vector{Symbol}) = join(String.(s), "⋅")
+decapode_edge_label(s::String) = s
+decapode_edge_label(s::Vector{String}) = join(s, "⋅")
 
 
 function Catlab.Graphics.to_graphviz_property_graph(d::AbstractNamedDecapode, directed = true; kw...)


### PR DESCRIPTION
Currently, the visualization code expects that edge labels are Symbols. During visualization, these Symbols are converted to Strings.

However, the types of such quantities in Decapodes read-in from JSON files are Strings.

So - without overhauling the visualization code - I implement a fix which relies on multiple dispatch to not "greedily" convert Symbols to Strings when assigning edge labels.