### PR TITLE
Ice Dynamics

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,9 +42,10 @@ makedocs(
   checkdocs = :none,
   pages     = Any[
     "Decapodes.jl" => "index.md",
-    "Overview" => "overview.md",
-    "Misc Features" => "bc_debug.md",
-    "Pipe Flow" => "poiseuille.md",
+    #"Overview" => "overview.md",
+    #"Misc Features" => "bc_debug.md",
+    #"Pipe Flow" => "poiseuille.md",
+    "Glacial Flow" => "ice_dynamics.md",
 #    "Examples" => Any[
 #      "examples/cfd_example.md"
 #    ],

--- a/docs/src/ice_dynamics.md
+++ b/docs/src/ice_dynamics.md
@@ -1,0 +1,481 @@
+# Halfar's model of glacial flow
+
+Let's model glacial flow using a model of how ice height of a glacial sheet changes over time, from P. Halfar's 1981 paper: "On the dynamics of the ice sheets".
+
+```
+# AlgebraicJulia Dependencies
+using Catlab
+using Catlab.Graphics
+using CombinatorialSpaces
+using Decapodes
+
+# External Dependencies
+using MLStyle
+using MultiScaleArrays
+using LinearAlgebra
+using OrdinaryDiffEq
+using JLD2
+using SparseArrays
+using Statistics
+using GLMakie
+using GeometryBasics: Point2
+Point2D = Point2{Float64};
+```
+
+# Defining the models
+
+The first step is to find a suitable equation for our model, and translate it into the Discrete Exterior Calculus. The Exterior Calculus is a generalization of vector calculus, so for low-dimensional spaces, this translation is straightforward. For example, divergence is typically written as (⋆, d, ⋆). Scalar fields are typically interpreted as "0Forms", i.e. values assigned to vertices of a mesh.
+
+We use the `@decapode` macro to interpret the equations. Here, we have equation 2 from Halfar:
+```math
+\frac{\partial h}{\partial t} = \frac{2}{n + 2} (\frac{\rho g}{A})^n \frac{\partial}{\partial x}(\frac{\partial h}{\partial x} |\frac{\partial h}{\partial x}| ^{n-1} h^{n+2}).
+```
+We'll change the term out front to Γ so we can demonstrate composition in a moment.
+
+```
+halfar_eq2 = @decapode begin
+  h::Form0
+  Γ::Form1
+  n::Constant
+
+  ḣ == ∂ₜ(h)
+  ḣ == ∘(⋆, d, ⋆)(Γ * d(h) * avg₀₁(mag(♯(d(h)))^(n-1)) * avg₀₁(h^(n+2)))
+end
+
+to_graphviz(halfar_eq2)
+```
+
+And here, a formulation of Glen's law from J.W. Glen's 1958 "The flow law of ice".
+```
+glens_law = @decapode begin
+  #Γ::Form0
+  Γ::Form1
+  (A,ρ,g,n)::Constant
+  
+  Γ == (2/(n+2))*A*(ρ*g)^n
+end
+
+to_graphviz(glens_law)
+```
+
+# Composing models
+
+We can use operadic composition to specify how our models come together. In this example, we have two Decapodes, and two quantities that are shared between them.
+```
+ice_dynamics_composition_diagram = @relation () begin
+  dynamics(n,Γ)
+  stress(Γ,n)
+end
+
+to_graphviz(ice_dynamics_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+```
+
+To a apply a composition, we specify which Decapodes to plug into those boxes, and what each calls the corresponding shared variables internally.
+
+```
+ice_dynamics_cospan = oapply(ice_dynamics_composition_diagram,
+  [Open(halfar_eq2, [:h,:Γ,:n]),
+  Open(glens_law, [:Γ,:n])])
+
+ice_dynamics = apex(ice_dynamics_cospan)
+to_graphviz(ice_dynamics)
+```
+
+# Provide a semantics
+
+To interpret our composed Decapode, we need to specify what Discrete Exterior Calculus to interpret our quantities in. Let's choose the 1D Discrete Exterior Calculus:
+```
+ice_dynamics1D = expand_operators(ice_dynamics)
+infer_types!(ice_dynamics1D, op1_inf_rules_1D, op2_inf_rules_1D)
+resolve_overloads!(ice_dynamics1D, op1_res_rules_1D, op2_res_rules_1D)
+
+to_graphviz(ice_dynamics1D)
+```
+
+# Define a mesh
+
+We'll need a mesh to simulate on. Since this is a 1D mesh, we can go ahead and make one right now:
+```
+# This is a 1D mesh, consisting of edges and vertices.
+s′ = EmbeddedDeltaSet1D{Bool, Point2D}()
+# 20 hundred vertices along a line, connected by edges.
+add_vertices!(s′, 20, point=Point2D.(range(0, 10_000, length=20), 0))
+add_edges!(s′, 1:nv(s′)-1, 2:nv(s′))
+orient!(s′)
+s = EmbeddedDeltaDualComplex1D{Bool, Float64, Point2D}(s′)
+subdivide_duals!(s, Circumcenter())
+```
+
+# Define input data
+
+We need initial conditions to use for our simulation.
+```
+n = 3
+ρ = 910
+g = 9.8
+A = 1e-16
+
+# Ice height is a primal 0-form, with values at vertices.
+# We choose a distribution that obeys the shallow height and shallow slope conditions.
+h₀ = map(point(s′)) do (x,_)
+  ((7072-((x-5000)^2))/9e3+2777)/2777e-1
+end
+
+# Visualize initial conditions for ice sheet height.
+lines(map(x -> x[1], point(s′)), h₀, linewidth=5)
+```
+
+We need to tell our Decapode which data maps to which symbols. We can wrap up our data like so:
+```
+u₀ = construct(PhysicsState, [VectorForm(h₀)], Float64[], [:h])
+constants_and_parameters = (
+  n = n,
+  stress_ρ = ρ,
+  stress_g = g,
+  stress_A = A)
+```
+
+# Define functions
+
+In order to solve our equations, we will need numerical linear operators that give meaning to our symbolic operators. In the DEC, there are a handful of operators that one uses to construct all the usual vector calculus operations, namely: ♯, ♭, ∧, d, ⋆. The CombinatorialSpaces.jl library specifies many of these for us.
+
+```
+function generate(sd, my_symbol; hodge=GeometricHodge())
+  op = @match my_symbol begin
+    :♯ => x -> begin
+      # This is an implementation of the "sharp" operator from the exterior
+      # calculus, which takes co-vector fields to vector fields.
+      # This could be up-streamed to the CombinatorialSpaces.jl library. (i.e.
+      # this operation is not bespoke to this simulation.)
+      e_vecs = map(edges(sd)) do e
+        point(sd, sd[e, :∂v0]) - point(sd, sd[e, :∂v1])
+      end
+      neighbors = map(vertices(sd)) do v
+        union(incident(sd, v, :∂v0), incident(sd, v, :∂v1))
+      end
+      n_vecs = map(neighbors) do es
+        [e_vecs[e] for e in es]
+      end
+      map(neighbors, n_vecs) do es, nvs
+        sum([nv*norm(nv)*x[e] for (e,nv) in zip(es,nvs)]) / sum(norm.(nvs))
+      end
+    end
+    :mag => x -> begin
+      norm.(x)
+    end
+    :avg₀₁ => x -> begin
+      I = Vector{Int64}()
+      J = Vector{Int64}()
+      V = Vector{Float64}()
+      for e in 1:ne(s)
+          append!(J, [s[e,:∂v0],s[e,:∂v1]])
+          append!(I, [e,e])
+          append!(V, [0.5, 0.5])
+      end
+      avg_mat = sparse(I,J,V)
+      avg_mat * x
+    end
+    :^ => (x,y) -> x .^ y
+    :* => (x,y) -> x .* y
+    :show => x -> begin
+      @show x
+      x
+    end
+    x => error("Unmatched operator $my_symbol")
+  end
+  return (args...) -> op(args...)
+end
+```
+
+# Generate the simulation
+
+Now, we have everything we need to generate our simulation:
+
+```
+sim = eval(gensim(ice_dynamics1D, dimension=1))
+fₘ = sim(s, generate)
+```
+
+# Pre-compile and run
+
+The first time that you run a function, Julia will pre-compile it, so that later runs will be fast. We'll solve our simulation for a short time span, to trigger this pre-compilation, and then run it.
+
+```
+@info("Precompiling Solver")
+prob = ODEProblem(fₘ, u₀, (0, 1e-8), constants_and_parameters)
+soln = solve(prob, Tsit5())
+soln.retcode != :Unstable || error("Solver was not stable")
+
+tₑ = 8e3
+
+# This next run should be fast.
+@info("Solving")
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+@show soln.retcode
+@info("Done")
+```
+
+We can save our solution file in case we want to examine its contents when this Julia session ends.
+
+```
+@save "ice_dynamics1D.jld2" soln
+```
+
+# Visualize
+
+Let's examine the final conditions:
+
+```
+fig,ax,ob = lines(map(x -> x[1], point(s′)), findnode(soln(tₑ), :h), linewidth=5)
+ylims!(ax, extrema(h₀))
+display(fig)
+```
+
+We see that our distribution converges to a more uniform ice height across our domain, which matches our physical intuition.
+
+Let's create a GIF to examine an animation of these dynamics:
+
+```
+# Create a gif
+begin
+  frames = 100
+  fig, ax, ob = lines(map(x -> x[1], point(s′)), findnode(soln(0), :h))
+  ylims!(ax, extrema(h₀))
+  record(fig, "ice_dynamics1D.gif", range(0.0, tₑ; length=frames); framerate = 15) do t
+    lines!(map(x -> x[1], point(s′)), findnode(soln(t), :h))
+  end
+end
+```
+
+![IceDynamics1D]("./ice_dynamics1D.gif")
+
+
+# 2D Re-interpretation
+
+The first, one-dimensional, semantics that we provided to our Decapode restricted the kinds of glacial sheets that we could model. (i.e. We could only look at glacial sheets which were constant along y). We can give our Decapode an alternate semantics, as some physics on a 2-dimensional manifold.
+
+Note that for these physics, we make no adjustments to the underlying "dimension-agnostic" Decapode, we only provide a different set of rules for inferring what the type of each quantity is.
+
+```
+ice_dynamics2D = expand_operators(ice_dynamics)
+infer_types!(ice_dynamics2D)
+resolve_overloads!(ice_dynamics2D)
+
+to_graphviz(ice_dynamics2D)
+```
+
+# Store as JSON
+
+We quickly demonstrate how to serialize a Decapode to JSON and read it back in:
+```
+write_json_acset(ice_dynamics2D, "ice_dynamics2D.json")
+```
+
+```
+# When reading back in, we specify that all attributes are "Symbol"s.
+ice_dynamics2 = read_json_acset(SummationDecapode{Symbol,Symbol,Symbol}, "ice_dynamics2D.json")
+# Or, you could choose to interpret the data as "String"s.
+ice_dynamics3 = read_json_acset(SummationDecapode{String,String,String}, "ice_dynamics2D.json")
+
+to_graphviz(ice_dynamics3)
+```
+
+# Define our mesh
+
+```
+include("../../grid_meshes.jl")
+s′ = triangulated_grid(10_000,10_000,800,800,Point3D)
+s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
+subdivide_duals!(s, Barycenter())
+wireframe(s)
+```
+
+# Define our input data
+
+```
+n = 3
+ρ = 910
+g = 9.8
+A = 1e-16
+
+# Ice height is a primal 0-form, with values at vertices.
+h₀ = map(point(s′)) do (x,y)
+  (7072-((x-5000)^2 + (y-5000)^2)^(1/2))/9e3+10
+end
+
+# Visualize initial condition for ice sheet height.
+mesh(s′, color=h₀, colormap=:jet)
+```
+
+```
+u₀ = construct(PhysicsState, [VectorForm(h₀)], Float64[], [:h])
+constants_and_parameters = (
+  n = n,
+  stress_ρ = ρ,
+  stress_g = g,
+  stress_A = A)
+```
+
+# Define our functions
+
+```
+function generate(sd, my_symbol; hodge=GeometricHodge())
+  op = @match my_symbol begin
+    :♯ => x -> begin
+      ♯(sd, EForm(x))
+    end
+    :mag => x -> begin
+      norm.(x)
+    end
+    :avg₀₁ => x -> begin
+      I = Vector{Int64}()
+      J = Vector{Int64}()
+      V = Vector{Float64}()
+      for e in 1:ne(s)
+          append!(J, [s[e,:∂v0],s[e,:∂v1]])
+          append!(I, [e,e])
+          append!(V, [0.5, 0.5])
+      end
+      avg_mat = sparse(I,J,V)
+      avg_mat * x
+    end
+    :^ => (x,y) -> x .^ y
+    :* => (x,y) -> x .* y
+    :show => x -> begin
+      @show x
+      @show length(x)
+      x
+    end
+    x => error("Unmatched operator $my_symbol")
+  end
+  return (args...) -> op(args...)
+end
+```
+
+# Generate simulation
+
+```
+sim = eval(gensim(ice_dynamics2D, dimension=2))
+fₘ = sim(s, generate)
+```
+
+# Pre-compile and run
+
+```
+@info("Precompiling Solver")
+# We run for a short timespan to pre-compile.
+prob = ODEProblem(fₘ, u₀, (0, 1e-8), constants_and_parameters)
+soln = solve(prob, Tsit5())
+soln.retcode != :Unstable || error("Solver was not stable")
+```
+
+```
+tₑ = 5e13
+
+@info("Solving")
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+@show soln.retcode
+@info("Done")
+```
+
+```
+@save "ice_dynamics2D.jld2" soln
+```
+
+# Visualize
+
+```
+# Final conditions:
+mesh(s′, color=findnode(soln(tₑ), :h), colormap=:jet, colorrange=extrema(findnode(soln(0), :h)))
+```
+
+```
+begin
+  frames = 100
+  fig, ax, ob = GLMakie.mesh(s′, color=findnode(soln(0), :h), colormap=:jet, colorrange=extrema(findnode(soln(0), :h)))
+  Colorbar(fig[1,2], ob)
+  record(fig, "ice_dynamics2D.gif", range(0.0, tₑ; length=frames); framerate = 15) do t
+    ob.color = findnode(soln(t), :h)
+  end
+end
+```
+
+![IceDynamics2D]("./ice_dynamics2D.gif")
+
+# 2-Manifold in 3D
+
+We note that just because our physics is happening on a 2-manifold, (a surface), this doesn't restrict us to the 2D plane. In fact, we can "embed" our 2-manifold in 3D space to simulate a glacial sheets spread across the globe.
+
+```
+s′ = loadmesh(Icosphere(3, 10_000))
+s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
+subdivide_duals!(s, Barycenter())
+wireframe(s)
+
+```
+
+```
+n = 3
+ρ = 910
+g = 9.8
+A = 1e-16
+
+# Ice height is a primal 0-form, with values at vertices.
+h₀ = map(point(s′)) do (x,y,z)
+  (z*z)/(10_000*10_000)
+end
+
+# Visualize initial condition for ice sheet height.
+# There is lots of ice at the poles, and no ice at the equator.
+mesh(s′, color=h₀, colormap=:jet)
+```
+
+```
+u₀ = construct(PhysicsState, [VectorForm(h₀)], Float64[], [:h])
+constants_and_parameters = (
+  n = n,
+  stress_ρ = ρ,
+  stress_g = g,
+  stress_A = A)
+```
+
+```
+sim = eval(gensim(ice_dynamics2D, dimension=2))
+fₘ = sim(s, generate)
+```
+
+```
+# For brevity's sake, we'll skip the pre-compilation cell.
+
+tₑ = 1e11
+
+@info("Solving")
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+@show soln.retcode
+@info("Done")
+
+# Compare the extrema of the initial and final conditions of ice height.
+extrema(findnode(soln(0), :h)), extrema(findnode(soln(tₑ), :h))
+```
+
+```
+mesh(s′, color=findnode(soln(tₑ), :h), colormap=:jet, colorrange=extrema(findnode(soln(0), :h)))
+```
+
+```
+begin
+  frames = 200
+  fig, ax, ob = GLMakie.mesh(s′, color=findnode(soln(0), :h), colormap=:jet, colorrange=extrema(findnode(soln(0), :h)))
+  Colorbar(fig[1,2], ob)
+  # These particular initial conditions diffuse quite quickly, so let's just look at
+  # the first moments of those dynamics.
+  record(fig, "ice_dynamics2D_sphere.gif", range(0.0, tₑ/64; length=frames); framerate = 20) do t
+    ob.color = findnode(soln(t), :h)
+  end
+end
+```
+
+![IceDynamics2DSphere]("./ice_dynamics2D_sphere.gif")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,6 +5,10 @@ Ultimately, this library will include tooling which takes advantage of the
 formalization of physical theories described by DEC provided by
 [CombinatorialSpaces.jl](https://algebraicjulia.github.io/CombinatorialSpaces.jl/dev/).
 
+# Getting started
+
+Walkthroughs creating, composing, and solving Decapodes are available in the side-bar of this documentation page. Further example scripts are avaiable in the `examples` folder of the Decapodes.jl GitHub repo, and will be added to this documentation site soon.
+
 # NOTE
 This library is currently under active development, and so is not yet at a
 point where a constant API/behavior can be assumed. That being said, if this

--- a/examples/climate/budyko_sellers.jl
+++ b/examples/climate/budyko_sellers.jl
@@ -94,7 +94,7 @@ budyko_sellers_cospan = oapply(budyko_sellers_composition_diagram,
 budyko_sellers = apex(budyko_sellers_cospan)
 to_graphviz(budyko_sellers)
 
-infer_types!(budyko_sellers, op1_inf_rules_1D, op2_inf_rules_2D)
+infer_types!(budyko_sellers, op1_inf_rules_1D, op2_inf_rules_1D)
 to_graphviz(budyko_sellers)
 
 resolve_overloads!(budyko_sellers, op1_res_rules_1D, op2_res_rules_1D)

--- a/examples/climate/budyko_sellers.jl
+++ b/examples/climate/budyko_sellers.jl
@@ -1,3 +1,7 @@
+#######################
+# Import Dependencies #
+#######################
+
 # AlgebraicJulia Dependencies
 using Catlab
 using Catlab.Graphics
@@ -26,27 +30,80 @@ Point2D = Point2{Float64}
 # A := Longwave emissions at 0°C
 # B := Increase in emissions per degree
 # D := Horizontal diffusivity
-budyko_sellers = @decapode begin
-    (Q,Tₛ)::Form0
-    (α,A,B,C,D,cosϕᵖ,cosϕᵈ)::Constant
 
-    Tₛ̇ == ∂ₜ(Tₛ)
-    ASR == (1 .- α) .* Q
-    OLR == A .+ (B .* Tₛ)
-    HT == (D ./ cosϕᵖ) .* ⋆(d(cosϕᵈ .* ⋆(d(Tₛ))))
+energy_balance = @decapode begin
+  (Tₛ, ASR, OLR, HT)::Form0
+  (C)::Constant
 
-    Tₛ̇ == (ASR - OLR + HT) ./ C
+  Tₛ̇ == ∂ₜ(Tₛ) 
+
+  Tₛ̇ == (ASR - OLR + HT) ./ C
 end
+to_graphviz(energy_balance)
 
-# Infer the forms of dependent variables, and resolve which versions of DEC
-# operators to use.
-infer_types!(budyko_sellers, op1_inf_rules_1D, op2_inf_rules_1D)
-resolve_overloads!(budyko_sellers, op1_res_rules_1D, op2_res_rules_1D)
+absorbed_shortwave_radiation = @decapode begin
+  (Q, ASR)::Form0
+  α::Constant
 
-# Visualize.
+  ASR == (1 .- α) .* Q
+end
+to_graphviz(absorbed_shortwave_radiation)
+
+outgoing_longwave_radiation = @decapode begin
+  (Tₛ, OLR)::Form0
+  (A,B)::Constant
+
+  OLR == A .+ (B .* Tₛ)
+end
+to_graphviz(outgoing_longwave_radiation)
+
+heat_transfer = @decapode begin
+  (HT, Tₛ)::Form0
+  (D,cosϕᵖ,cosϕᵈ)::Constant
+
+  HT == (D ./ cosϕᵖ) .* ⋆(d(cosϕᵈ .* ⋆(d(Tₛ))))
+end
+to_graphviz(heat_transfer)
+
+insolation = @decapode begin
+  Q::Form0
+  cosϕᵖ::Constant
+
+  Q == 450 * cosϕᵖ
+end
+to_graphviz(insolation)
+
+to_graphviz(oplus([energy_balance, absorbed_shortwave_radiation, outgoing_longwave_radiation, heat_transfer, insolation]))
+
+budyko_sellers_composition_diagram = @relation () begin
+  energy(Tₛ, ASR, OLR, HT)
+  absorbed_radiation(Q, ASR)
+  outgoing_radiation(Tₛ, OLR)
+  diffusion(Tₛ, HT, cosϕᵖ)
+  insolation(Q, cosϕᵖ)
+end
+to_graphviz(budyko_sellers_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+
+budyko_sellers_cospan = oapply(budyko_sellers_composition_diagram,
+  [Open(energy_balance, [:Tₛ, :ASR, :OLR, :HT]),
+   Open(absorbed_shortwave_radiation, [:Q, :ASR]),
+   Open(outgoing_longwave_radiation, [:Tₛ, :OLR]),
+   Open(heat_transfer, [:Tₛ, :HT, :cosϕᵖ]),
+   Open(insolation, [:Q, :cosϕᵖ])])
+
+budyko_sellers = apex(budyko_sellers_cospan)
 to_graphviz(budyko_sellers)
 
-# Demonstrate storing as JSON.
+infer_types!(budyko_sellers, op1_inf_rules_1D, op2_inf_rules_2D)
+to_graphviz(budyko_sellers)
+
+resolve_overloads!(budyko_sellers, op1_res_rules_1D, op2_res_rules_1D)
+to_graphviz(budyko_sellers)
+
+###############################
+# Demonstrate storing as JSON #
+###############################
+
 write_json_acset(budyko_sellers, "budyko_sellers.json")
 # When reading back in, we specify that all attributes are "Symbol"s.
 budyko_sellers2 = read_json_acset(SummationDecapode{Symbol,Symbol,Symbol}, "budyko_sellers.json")
@@ -72,13 +129,13 @@ subdivide_duals!(s, Circumcenter())
 cosϕᵖ = map(x -> cos(x[1]), point(s′))
 # This is a dual 0-form, with values at edge centers.
 cosϕᵈ = map(edges(s′)) do e
-    (cos(point(s′, src(s′, e))[1]) + cos(point(s′, tgt(s′, e))[1])) / 2
+  (cos(point(s′, src(s′, e))[1]) + cos(point(s′, tgt(s′, e))[1])) / 2
 end
 
 α₀ = 0.354
 α₂ = 0.25
 α = map(point(s′)) do ϕ
-    α₀ + α₂*((1/2)*(3*ϕ[1]^2 - 1))
+  α₀ + α₂*((1/2)*(3*ϕ[1]^2 - 1))
 end
 A = 210
 B = 2
@@ -87,59 +144,36 @@ f = 0.70
 cw = 4186
 H = 70
 C = map(point(s′)) do ϕ
-    f * ρ * cw * H
+  f * ρ * cw * H
 end
 D = 0.6
-Q = map(point(s′)) do ϕ
-    450*cos(ϕ[1])
-end
 
 #Tₛ₀ = map(point(s′)) do ϕ
 #    12 .- 40*((1/2)*(3*(sin(ϕ[1]))^2 - 1))
 #end
-# Isothermal:
+# Isothermal initial conditions:
 Tₛ₀ = map(point(s′)) do ϕ
-    15
+  15
 end
 
 # Store these values to be passed to the solver.
-u₀ = construct(PhysicsState, [VectorForm(Q), VectorForm(Tₛ₀)], Float64[], [:Q, :Tₛ])
+u₀ = construct(PhysicsState, [VectorForm(Tₛ₀)], Float64[], [:Tₛ])
 constants_and_parameters = (
-    α = α,
-    A = A,
-    B = B,
-    C = C,
-    D = D,
-    cosϕᵖ = cosϕᵖ,
-    cosϕᵈ = cosϕᵈ)
+  absorbed_radiation_α = α,
+  outgoing_radiation_A = A,
+  outgoing_radiation_B = B,
+  energy_C = C,
+  diffusion_D = D,
+  cosϕᵖ = cosϕᵖ,
+  diffusion_cosϕᵈ = cosϕᵈ)
 
 #############################################
 # Define how symbols map to Julia functions #
 #############################################
 
-hodge = GeometricHodge()
-function generate(sd, my_symbol; hodge=GeometricHodge())
-  op = @match my_symbol begin
-    :d₀ => x -> begin
-      d₀ = d(s,0)
-      d₀ * x
-    end
-    :dual_d₀ => x -> begin
-      dual_d₀ = dual_derivative(s,0)
-      dual_d₀ * x
-    end
-    :⋆₁ => x -> begin
-      ⋆₁ = ⋆(s,1)
-      ⋆₁ * x
-    end
-    :⋆₀⁻¹ => x -> begin
-      ⋆₀⁻¹ = inv_hodge_star(s,0)
-      ⋆₀⁻¹ * x
-    end
-    x => error("Unmatched operator $my_symbol")
-  end
-  return (args...) -> op(args...)
-end
+# In this example, all operators come from the Discrete Exterior Calculus module
+# from CombinatorialSpaces.
+function generate(sd, my_symbol; hodge=GeometricHodge()) end
 
 #######################
 # Generate simulation #
@@ -152,7 +186,7 @@ fₘ = sim(s, generate)
 # Run simulation #
 ##################
 
-tₑ = 1e6
+tₑ = 1e9
 
 # Julia will pre-compile the generated simulation the first time it is run.
 @info("Precompiling Solver")
@@ -164,6 +198,7 @@ soln.retcode != :Unstable || error("Solver was not stable")
 @info("Solving")
 prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
 soln = solve(prob, Tsit5())
+@show soln.retcode
 @info("Done")
 
 @save "budyko_sellers.jld2" soln
@@ -180,7 +215,8 @@ fig = Figure(resolution = (800, 800))
 ax1 = Axis(fig[1,1])
 xlims!(ax1, extrema(map(x -> x[1], point(s′))))
 ylims!(ax1, extrema(findnode(soln(tₑ), :Tₛ)))
-Label(fig[1,1,Top()], "Tₛ")
+Label(fig[1,1,Top()], "Surface temperature, Tₛ, [C°]")
+Label(fig[2,1,Top()], "Line plot of temperature from North to South pole, every $(tₑ/frames) time units")
 
 # Animation
 frames = 100

--- a/examples/climate/budyko_sellers.jl
+++ b/examples/climate/budyko_sellers.jl
@@ -73,7 +73,7 @@ insolation = @decapode begin
 end
 to_graphviz(insolation)
 
-to_graphviz(oplus([energy_balance, absorbed_shortwave_radiation, outgoing_longwave_radiation, heat_transfer, insolation]))
+to_graphviz(oplus([energy_balance, absorbed_shortwave_radiation, outgoing_longwave_radiation, heat_transfer, insolation]), directed=false)
 
 budyko_sellers_composition_diagram = @relation () begin
   energy(Tₛ, ASR, OLR, HT)

--- a/examples/climate/nonhydrostatic_buoyancy.jl
+++ b/examples/climate/nonhydrostatic_buoyancy.jl
@@ -22,6 +22,7 @@ Point3D = Point3{Float64}
 # Define the model #
 ####################
 
+# Equation 1: "The momentum conservation equation" from https://clima.github.io/OceananigansDocumentation/stable/physics/nonhydrostatic_model/#The-momentum-conservation-equation
 momentum = @decapode begin
   (f,b)::Form0
   (v,V,g,Fᵥ,uˢ,v_up)::Form1
@@ -36,16 +37,18 @@ momentum = @decapode begin
   uˢ̇ == force(U)
 end
 momentum = expand_operators(momentum)
-to_graphviz(momentum)
+to_graphviz(momentum, graph_attrs=Dict(:rankdir => "LR"))
 
+# Equation 2: "The tracer conservation equation" from https://clima.github.io/OceananigansDocumentation/stable/physics/nonhydrostatic_model/#The-tracer-conservation-equation
 tracer = @decapode begin
   (c,C,F,c_up)::Form0
   (v,V,q)::Form1
 
   c_up == -1*⋆(L(v,⋆(c))) - ⋆(L(V,⋆(c))) - ⋆(L(v,⋆(C))) - ∘(⋆,d,⋆)(q) + F
 end
-to_graphviz(tracer)
+to_graphviz(tracer, graph_attrs=Dict(:rankdir => "LR"))
 
+# Equation 2: "Linear equation of state" of seawater buoyancy from https://clima.github.io/OceananigansDocumentation/stable/physics/buoyancy_and_equations_of_state/#Linear-equation-of-state
 equation_of_state = @decapode begin
   (b,T,S)::Form0
   (g,α,β)::Constant
@@ -100,7 +103,7 @@ to_graphviz(buoyancy)
 
 include("../../grid_meshes.jl")
 #s′ = loadmesh(Rectangle_30x10())
-s′ = triangulated_grid(80,80, 2, 2, Point3D)
+s′ = triangulated_grid(80,80, 10, 10, Point3D)
 s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
 subdivide_duals!(s, Barycenter())
 xmax = maximum(x -> x[1], point(s))
@@ -255,68 +258,46 @@ end
 
 begin end
 
-## Track a single tracer.
-#single_tracer_composition_diagram = @relation () begin
-#  momentum(V, v)
-#  tracer(V, v)
-#end
-#to_graphviz(single_tracer_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
-#
-#single_tracer_cospan = oapply(single_tracer_composition_diagram,
-#  [Open(momentum, [:V, :v]),
-#  Open(tracer, [:V, :v])])
-#
-#single_tracer = apex(single_tracer_cospan)
-#to_graphviz(single_tracer)
-#
-#single_tracer = expand_operators(single_tracer)
-#infer_types!(single_tracer)
-#resolve_overloads!(single_tracer)
-#to_graphviz(single_tracer)
-#
-#
-## Track multiple tracers.
-#triple_tracer_composition_diagram = @relation () begin
-#  momentum(V, v)
-#
-#  mercury(V, v)
-#  phosphate(V, v)
-#  oil(V, v)
-#end
-#to_graphviz(triple_tracer_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
-#
-#triple_tracer_cospan = oapply(triple_tracer_composition_diagram,
-#  [Open(momentum, [:V, :v]),
-#  Open(tracer, [:V, :v]),
-#  Open(tracer, [:V, :v]),
-#  Open(tracer, [:V, :v])])
-#
-#triple_tracer = apex(triple_tracer_cospan)
-#to_graphviz(triple_tracer)
-#
-#triple_tracer = expand_operators(triple_tracer)
-#infer_types!(triple_tracer)
-#resolve_overloads!(triple_tracer)
-#to_graphviz(triple_tracer)
-#
-#
-## The buoyancy model uses b as a tracer.
-#buoyancy_composition_diagram = @relation () begin
-#  momentum(V, v, b)
-#
-#  # "b obeys the tracer equation"
-#  tracer(V, v, b)
-#end
-#to_graphviz(buoyancy_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
-#
-#buoyancy_cospan = oapply(buoyancy_composition_diagram,
-#  [Open(momentum, [:V, :v, :b]),
-#  Open(tracer, [:V, :v, :c])])
-#
-#buoyancy = apex(buoyancy_cospan)
-#to_graphviz(buoyancy)
-#
-#buoyancy = expand_operators(buoyancy)
-#infer_types!(buoyancy)
-#resolve_overloads!(buoyancy)
-#to_graphviz(buoyancy)
+# Track a single tracer.
+single_tracer_composition_diagram = @relation () begin
+  momentum(V, v)
+  tracer(V, v)
+end
+to_graphviz(single_tracer_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+
+single_tracer_cospan = oapply(single_tracer_composition_diagram,
+  [Open(momentum, [:V, :v]),
+  Open(tracer, [:V, :v])])
+
+single_tracer = apex(single_tracer_cospan)
+to_graphviz(single_tracer)
+
+single_tracer = expand_operators(single_tracer)
+infer_types!(single_tracer)
+resolve_overloads!(single_tracer)
+to_graphviz(single_tracer)
+
+
+# Track multiple tracers.
+triple_tracer_composition_diagram = @relation () begin
+  momentum(V, v)
+
+  mercury(V, v)
+  phosphate(V, v)
+  oil(V, v)
+end
+to_graphviz(triple_tracer_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+
+triple_tracer_cospan = oapply(triple_tracer_composition_diagram,
+  [Open(momentum, [:V, :v]),
+  Open(tracer, [:V, :v]),
+  Open(tracer, [:V, :v]),
+  Open(tracer, [:V, :v])])
+
+triple_tracer = apex(triple_tracer_cospan)
+to_graphviz(triple_tracer)
+
+triple_tracer = expand_operators(triple_tracer)
+infer_types!(triple_tracer)
+resolve_overloads!(triple_tracer)
+to_graphviz(triple_tracer)

--- a/examples/climate/nonhydrostatic_buoyancy.jl
+++ b/examples/climate/nonhydrostatic_buoyancy.jl
@@ -90,7 +90,9 @@ include("../../grid_meshes.jl")
 s′ = triangulated_grid(80,80, 10, 10, Point3D)
 s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
 subdivide_duals!(s, Barycenter())
+wireframe(s)
 
+# Some extra operators that haven't been up-streamed into CombinatorialSpaces yet.
 include("dec_operators.jl")
 function generate(sd, my_symbol; hodge=GeometricHodge())
   op = @match my_symbol begin
@@ -105,14 +107,16 @@ end
 sim = eval(gensim(buoyancy))
 fₘ = sim(s, generate)
 
+xmax = maximum(x -> x[1], point(s))
 zmax = maximum(x -> x[2], point(s))
 S = map(point(s)) do (_,_,_)
-  10.0
+  35.0
 end
-T = map(point(s)) do (_,z,_)
-  273.15 + 4 + (zmax-z)/(zmax)*2
+T = map(point(s)) do (x,z,_)
+  273.15 + 4 + ((zmax-z)^2 + (xmax-x)^2)^(1/2)/(1e2)
 end
 extrema(T)
+mesh(s′, color=T, colormap=:jet)
 p = zeros(nv(s))
 f = zeros(nv(s))
 Fₛ = zeros(nv(s))
@@ -196,6 +200,7 @@ soln = solve(prob, Tsit5())
 @info("Done")
 
 mesh(s′, color=findnode(soln(3.1), :T), colormap=:jet)
+extrema(findnode(soln(3.1), :T))
 
 # Create a gif
 begin

--- a/examples/climate/nonhydrostatic_buoyancy.jl
+++ b/examples/climate/nonhydrostatic_buoyancy.jl
@@ -1,0 +1,237 @@
+# This is a 50 line implementation of Oceananigans.jl's NonhydrostaticModel.
+
+#######################
+# Import Dependencies #
+#######################
+
+# AlgebraicJulia Dependencies
+using Catlab
+using CombinatorialSpaces
+using Decapodes
+
+# External Dependencies
+using GeometryBasics: Point3
+using GLMakie
+using JLD2
+using LinearAlgebra
+using MultiScaleArrays
+using OrdinaryDiffEq
+Point3D = Point3{Float64}
+
+####################
+# Define the model #
+####################
+
+momentum = @decapode begin
+  (f,b)::Form0
+  (v,V,g,Fᵥ,uˢ)::Form1
+  τ::Form2
+  v̇ == ∂ₜ(v)
+
+  v̇ == -1 * L(v,v) - L(V,v) - L(v,V) -
+       f∧v - ∘(⋆,d,⋆)(uˢ)∧v - d(p) + b∧g - ∘(⋆,d,⋆)(τ) + dtuˢ + Fᵥ
+end
+momentum = expand_operators(momentum)
+to_graphviz(momentum)
+
+tracer = @decapode begin
+  (c,F)::Form0
+  (v,V,q)::Form1
+  ċ == ∂ₜ(c)
+
+  ċ == -1*⋆(L(v,⋆(c))) - ⋆(L(V,⋆(c))) - ⋆(L(v,⋆(c))) - ∘(⋆,d,⋆)(q) + F
+end
+to_graphviz(tracer)
+
+equation_of_state = @decapode begin
+  (b,T,S)::Form0
+  (g,α,β)::Constant
+
+  b == g*(α*T - β*S)
+end
+to_graphviz(equation_of_state)
+
+buoyancy_composition_diagram = @relation () begin
+  momentum(V, v, b)
+
+  # "Both T and S obey the tracer conservation equation"
+  temperature(V, v, T)
+  salinity(V, v, S)
+
+  # "Buoyancy is determined from a linear equation of state"
+  eos(b, T, S)
+end
+to_graphviz(buoyancy_composition_diagram, box_labels=:name, junction_labels=:variable, prog="fdp", graph_attrs=Dict(["sep" => "1.5"]))
+
+buoyancy_cospan = oapply(buoyancy_composition_diagram, [
+  Open(momentum,          [:V, :v, :b]),
+  Open(tracer,            [:V, :v, :c]),
+  Open(tracer,            [:V, :v, :c]),
+  Open(equation_of_state, [:b, :T, :S])])
+
+buoyancy = apex(buoyancy_cospan)
+to_graphviz(buoyancy)
+
+buoyancy = expand_operators(buoyancy)
+infer_types!(buoyancy)
+resolve_overloads!(buoyancy)
+to_graphviz(buoyancy)
+
+s′ = loadmesh(Rectangle_30x10())
+s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
+subdivide_duals!(s, Barycenter())
+
+include("dec_operators.jl")
+function generate(sd, my_symbol; hodge=GeometricHodge())
+  op = @match my_symbol begin
+    :L₁ => (x,y) -> L₁′(x,y,sd,hodge)
+    :L₂ᵈ => (x,y) -> lie_derivative_flat(2, sd, x, y)
+    _ => default_dec_generate(sd, my_symbol, hodge)
+  end
+  return (args...) -> op(args...)
+end
+
+sim = eval(gensim(buoyancy))
+fₘ = sim(s, generate)
+
+S = zeros(nv(s))
+T = zeros(nv(s))
+p = zeros(nv(s))
+f = zeros(nv(s))
+Fₛ = zeros(nv(s))
+Fₜ = zeros(nv(s))
+f = zeros(nv(s))
+
+V = zeros(ne(s))
+v = zeros(ne(s))
+g = ♭(sd, DualVectorField(fill(Point3D(0,1,0), ntriangles(s)))).data
+Fᵥ = zeros(ne(s))
+qₛ = zeros(ne(s))
+qₜ = zeros(ne(s))
+uˢ = zeros(ne(s))
+dtuˢ = zeros(ne(s))
+
+τ = zeros(ntriangles(s))
+
+u₀ = construct(PhysicsState, [
+  VectorForm(f),
+  VectorForm(v),
+  VectorForm(V),
+  VectorForm(g),
+  VectorForm(Fᵥ),
+  VectorForm(uˢ),
+  VectorForm(τ),
+  VectorForm(dtuˢ),
+  VectorForm(p),
+  VectorForm(T),
+  VectorForm(Fₜ),
+  VectorForm(qₜ),
+  VectorForm(S),
+  VectorForm(Fₛ),
+  VectorForm(qₛ)], Float64[], [
+  :momentum_f,
+  :v,
+  :V,
+  :momentum_g,
+  :momentum_Fᵥ,
+  :momentum_uˢ,
+  :momentum_τ,
+  :momentum_dtuˢ,
+  :momentum_p,
+  :T,
+  :temperature_F,
+  :temperature_q,
+  :S,
+  :salinity_F,
+  :salinity_q])
+
+gᶜ = 0
+α = 0
+β = 0
+constants_and_parameters = (
+  eos_g = gᶜ,
+  eos_α = α,
+  eos_β = β)
+
+tₑ = 1e9
+
+# Julia will pre-compile the generated simulation the first time it is run.
+@info("Precompiling Solver")
+prob = ODEProblem(fₘ, u₀, (0, 1e-4), constants_and_parameters)
+soln = solve(prob, Tsit5())
+soln.retcode != :Unstable || error("Solver was not stable")
+
+# This next run should be fast.
+@info("Solving")
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+@show soln.retcode
+@info("Done")
+
+begin end
+
+## Track a single tracer.
+#single_tracer_composition_diagram = @relation () begin
+#  momentum(V, v)
+#  tracer(V, v)
+#end
+#to_graphviz(single_tracer_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+#
+#single_tracer_cospan = oapply(single_tracer_composition_diagram,
+#  [Open(momentum, [:V, :v]),
+#  Open(tracer, [:V, :v])])
+#
+#single_tracer = apex(single_tracer_cospan)
+#to_graphviz(single_tracer)
+#
+#single_tracer = expand_operators(single_tracer)
+#infer_types!(single_tracer)
+#resolve_overloads!(single_tracer)
+#to_graphviz(single_tracer)
+#
+#
+## Track multiple tracers.
+#triple_tracer_composition_diagram = @relation () begin
+#  momentum(V, v)
+#
+#  mercury(V, v)
+#  phosphate(V, v)
+#  oil(V, v)
+#end
+#to_graphviz(triple_tracer_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+#
+#triple_tracer_cospan = oapply(triple_tracer_composition_diagram,
+#  [Open(momentum, [:V, :v]),
+#  Open(tracer, [:V, :v]),
+#  Open(tracer, [:V, :v]),
+#  Open(tracer, [:V, :v])])
+#
+#triple_tracer = apex(triple_tracer_cospan)
+#to_graphviz(triple_tracer)
+#
+#triple_tracer = expand_operators(triple_tracer)
+#infer_types!(triple_tracer)
+#resolve_overloads!(triple_tracer)
+#to_graphviz(triple_tracer)
+#
+#
+## The buoyancy model uses b as a tracer.
+#buoyancy_composition_diagram = @relation () begin
+#  momentum(V, v, b)
+#
+#  # "b obeys the tracer equation"
+#  tracer(V, v, b)
+#end
+#to_graphviz(buoyancy_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+#
+#buoyancy_cospan = oapply(buoyancy_composition_diagram,
+#  [Open(momentum, [:V, :v, :b]),
+#  Open(tracer, [:V, :v, :c])])
+#
+#buoyancy = apex(buoyancy_cospan)
+#to_graphviz(buoyancy)
+#
+#buoyancy = expand_operators(buoyancy)
+#infer_types!(buoyancy)
+#resolve_overloads!(buoyancy)
+#to_graphviz(buoyancy)

--- a/examples/climate/shallow_ice.jl
+++ b/examples/climate/shallow_ice.jl
@@ -40,6 +40,10 @@ glens_law = @decapode begin
 end
 to_graphviz(glens_law)
 
+#####################
+# Compose the model #
+#####################
+
 ice_dynamics_composition_diagram = @relation () begin
   dynamics(h,Γ,n)
   stress(Γ,n)
@@ -62,7 +66,10 @@ to_graphviz(ice_dynamics)
 resolve_overloads!(ice_dynamics)
 to_graphviz(ice_dynamics)
 
-# Demonstrate storing as JSON.
+###################
+# Store the model #
+###################
+
 write_json_acset(ice_dynamics, "ice_dynamics.json")
 # When reading back in, we specify that all attributes are "Symbol"s.
 ice_dynamics2 = read_json_acset(SummationDecapode{Symbol,Symbol,Symbol}, "ice_dynamics.json")
@@ -88,7 +95,6 @@ n = 3
 ρ = 910
 g = 9.8
 A = 1e-16
-Γ = (2/(n+2))*A*(ρ*g)^n
 
 # Ice height is a primal 0-form, with values at vertices.
 h₀ = map(point(s′)) do (x,y)
@@ -197,116 +203,3 @@ begin
     ob.color = findnode(soln(t), :h)
   end
 end
-
-
-begin end
-
-
-
-
-
-
-
-
-
-## Equation 1 from Halfar, P. ON THE DYNAMICS OF THE ICE SHEETS. (1981)
-#halfar_eq1 = @decapode begin
-#  h::Form0
-#  (Γ,n)::Constant
-#
-#  ḣ == ∂ₜ(h)
-#  #ḣ == -1 * Γ * ∘(⋆, d, ⋆)(d(h) .* abs(d(h))^(n-1) .* avg₀₁(h^(n+2)))
-#  ḣ == Γ * ∘(⋆, d, ⋆)(d(h) .* abs(d(h))^(n-1) .* avg₀₁(h^(n+2)))
-#  #ḣ == ∘(⋆, d, ⋆)(Γ * avg₀₁(h^(n+2)) .* abs(d(h))^(n-1) .* d(h))
-#end
-#
-## Equation 1 from Glen, J. W. THE FLOW LAW OF ICE: A discussion of the
-## assumptions made in glacier theory, their experimental foundations and
-## consequences. (1958)
-#glen_eq1 = @decapode begin
-#  (ϵ,σ,A,n)::Constant
-#
-#  ϵ == (σ/A)^n
-#end
-#
-## Equation 1 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF ICE
-## SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
-#mahaffy_eq1 = @decapode begin
-#  h::Form0
-#  (ϵ,σ,A,n)::Constant
-#  b::Parameter
-#
-#  ḣ == ∂ₜ(h)
-#  ḣ == b - ∘(⋆, d, ⋆)(q)
-#end
-#
-## Equations 9 and 10 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF
-## ICE SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
-#mahaffy_eqs9_10 = @decapode begin
-#  h::Form0
-#  (σ,ρ,g)::Constant
-#
-#  σ == -ρ * g * (h-z) * d(h)
-#end
-#
-## Equation 13 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF ICE
-## SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
-#mahaffy_eq13 = @decapode begin
-#  h::Form0
-#  α::Form1
-#
-#  α == abs(d(h))
-#end
-#
-## Equations 14 and 15 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF
-## ICE SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
-#mahaffy_eqs14_15 = @decapode begin
-#  h::Form0
-#  (α,q)::Form1
-#
-#end
-## Infer the forms of dependent variables, and resolve which versions of DEC
-## operators to use.
-#halfar = expand_operators(halfar_eq1)
-#infer_types!(expand_operators(ice_dynamics))
-#resolve_overloads!(ice_dynamics)
-#infer_types!(halfar, op1_inf_rules_2D,
-#  vcat(op2_inf_rules_2D, [
-#    (proj1_type = :Constant, proj2_type = :Literal, res_type = :Constant, op_names = [:/, :./, :*, :.*]),
-#    (proj1_type = :Literal, proj2_type = :Constant, res_type = :Constant, op_names = [:/, :./, :*, :.*])]
-#  ))
-#resolve_overloads!(halfar)
-#
-## Visualize.
-#to_graphviz(halfar)
-#to_graphviz(ice_dynamics)
-#constants_and_parameters = (
-#  n = n,
-#  ρ = ρ,
-#  g = g,
-#  A = A,
-#  Γ = Γ)
-#prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
-#soln = solve(prob, Tsit5())
-#extrema(findnode(soln(0.0), :h))
-#extrema(findnode(soln(tₑ ), :h))
-#
-#extrema(d0s * findnode(soln(0.0), :h))
-#extrema(d0s * findnode(soln(tₑ ), :h))
-
-#sim = eval(gensim(halfar, dimension=2))
-#fₘ = sim(s, generate)
-#@save "halfar.jld2" soln
-#begin # BEGIN Gif creation
-#frames = 100
-## Initial frame
-##fig = GLMakie.Figure(resolution = (400, 400))
-#fig, ax, ob = GLMakie.mesh(s′, color=findnode(soln(0), :h), colormap=:jet, colorrange=extrema(findnode(soln(tₑ), :h)))
-#Colorbar(fig[1,2], ob)
-#
-## Animation
-#record(fig, "halfar.gif", range(0.0, tₑ; length=frames); framerate = 30) do t
-#    ob.color = findnode(soln(t), :h)
-#end
-#
-#end # END Gif creation

--- a/examples/climate/shallow_ice.jl
+++ b/examples/climate/shallow_ice.jl
@@ -1,0 +1,312 @@
+# AlgebraicJulia Dependencies
+using Catlab
+using Catlab.Graphics
+using CombinatorialSpaces
+using Decapodes
+
+# External Dependencies
+using MLStyle
+using MultiScaleArrays
+using LinearAlgebra
+using OrdinaryDiffEq
+using JLD2
+using SparseArrays
+using GLMakie
+using GeometryBasics: Point2
+Point2D = Point2{Float64}
+
+####################
+# Define the model #
+####################
+
+# Equation 2 from Halfar, P. ON THE DYNAMICS OF THE ICE SHEETS. (1981)
+halfar_eq2 = @decapode begin
+  (h,Γ)::Form0
+  n::Constant
+
+  ḣ == ∂ₜ(h)
+  ḣ == ∘(⋆, d, ⋆)(Γ .* d(h) .* abs(d(h))^(n-1) .* avg₀₁(h^(n+2)))
+end
+to_graphviz(halfar_eq2)
+
+# Equation 1 from Glen, J. W. THE FLOW LAW OF ICE: A discussion of the
+# assumptions made in glacier theory, their experimental foundations and
+# consequences. (1958)
+glens_law = @decapode begin
+  Γ::Form0
+  (A,ρ,g,n)::Constant
+  
+  Γ == (2/(n+2))*A*(ρ*g)^n
+end
+to_graphviz(glens_law)
+
+ice_dynamics_composition_diagram = @relation () begin
+  dynamics(h,Γ,n)
+  stress(Γ,n)
+end
+to_graphviz(ice_dynamics_composition_diagram, box_labels=:name, junction_labels=:variable, prog="circo")
+
+ice_dynamics_cospan = oapply(ice_dynamics_composition_diagram,
+  [Open(halfar_eq2, [:h,:Γ,:n]),
+  Open(glens_law, [:Γ,:n])])
+
+ice_dynamics = apex(ice_dynamics_cospan)
+to_graphviz(ice_dynamics)
+
+ice_dynamics = expand_operators(ice_dynamics)
+to_graphviz(ice_dynamics)
+
+infer_types!(ice_dynamics)
+to_graphviz(ice_dynamics)
+
+resolve_overloads!(ice_dynamics)
+to_graphviz(ice_dynamics)
+
+# Demonstrate storing as JSON.
+write_json_acset(ice_dynamics, "ice_dynamics.json")
+# When reading back in, we specify that all attributes are "Symbol"s.
+ice_dynamics2 = read_json_acset(SummationDecapode{Symbol,Symbol,Symbol}, "ice_dynamics.json")
+to_graphviz(ice_dynamics2)
+# Or, you could choose to interpret the data as "String"s.
+ice_dynamics3 = read_json_acset(SummationDecapode{String,String,String}, "ice_dynamics.json")
+to_graphviz(ice_dynamics3)
+
+###################
+# Define the mesh #
+###################
+
+include("../../grid_meshes.jl")
+s′ = triangulated_grid(10_000,10_000,800,800,Point3D)
+s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
+subdivide_duals!(s, Barycenter())
+
+########################################################
+# Define constants, parameters, and initial conditions #
+########################################################
+
+n = 3
+ρ = 910
+g = 9.8
+A = 1e-16
+Γ = (2/(n+2))*A*(ρ*g)^n
+
+# Ice height is a primal 0-form, with values at vertices.
+h₀ = map(point(s′)) do (x,y)
+  10 + (1e-7)*((x-32)^2 + (y-32)^2)
+end
+
+# Visualize initial condition for ice sheet height.
+mesh(s′, color=h₀, colormap=:jet)
+
+# Store these values to be passed to the solver.
+u₀ = construct(PhysicsState, [VectorForm(h₀)], Float64[], [:h])
+constants_and_parameters = (
+  n = n,
+  stress_ρ = ρ,
+  stress_g = g,
+  stress_A = A)
+
+#############################################
+# Define how symbols map to Julia functions #
+#############################################
+
+hodge = GeometricHodge()
+function generate(sd, my_symbol; hodge=GeometricHodge())
+  op = @match my_symbol begin
+    :d₀ => x -> begin
+      d₀ = d(s,0)
+      d₀ * x
+    end
+    :dual_d₀ => x -> begin
+      dual_d₀ = dual_derivative(s,0)
+      dual_d₀ * x
+    end
+    :⋆₁ => x -> begin
+      ⋆₁ = ⋆(s,1)
+      ⋆₁ * x
+    end
+    :⋆₀⁻¹ => x -> begin
+      ⋆₀⁻¹ = inv_hodge_star(s,0)
+      ⋆₀⁻¹ * x
+    end
+    :avg₀₁ => x -> begin
+      I = Vector{Int64}()
+      J = Vector{Int64}()
+      V = Vector{Float64}()
+      for e in 1:ne(s)
+          append!(J, [s[e,:∂v0],s[e,:∂v1]])
+          append!(I, [e,e])
+          append!(V, [0.5, 0.5])
+      end
+      avg_mat = sparse(I,J,V)
+      avg_mat * x
+    end
+    :^ => (x,y) -> x .^ y
+    :* => (x,y) -> x .* y
+    :abs => x -> abs.(x)
+    :show => x -> begin
+      println(x)
+      x
+    end
+    x => error("Unmatched operator $my_symbol")
+  end
+  return (args...) -> op(args...)
+end
+
+#######################
+# Generate simulation #
+#######################
+
+sim = eval(gensim(ice_dynamics, dimension=2))
+fₘ = sim(s, generate)
+
+##################
+# Run simulation #
+##################
+
+tₑ = 3e5
+
+# Julia will pre-compile the generated simulation the first time it is run.
+@info("Precompiling Solver")
+prob = ODEProblem(fₘ, u₀, (0, 1e-8), constants_and_parameters)
+soln = solve(prob, Tsit5())
+soln.retcode != :Unstable || error("Solver was not stable")
+
+# This next run should be fast.
+@info("Solving")
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+@show soln.retcode
+@info("Done")
+
+@save "ice_dynamics.jld2" soln
+
+#############
+# Visualize #
+#############
+
+# Visualize the final conditions.
+mesh(s′, color=findnode(soln(tₑ), :h), colormap=:jet)
+
+# Create a gif
+begin
+  frames = 100
+  fig, ax, ob = GLMakie.mesh(s′, color=findnode(soln(0), :h), colormap=:jet, colorrange=extrema(findnode(soln(tₑ), :h)))
+  Colorbar(fig[1,2], ob)
+  record(fig, "ice_dynamics.gif", range(0.0, tₑ; length=frames); framerate = 30) do t
+    ob.color = findnode(soln(t), :h)
+  end
+end
+
+
+begin end
+
+
+
+
+
+
+
+
+
+## Equation 1 from Halfar, P. ON THE DYNAMICS OF THE ICE SHEETS. (1981)
+#halfar_eq1 = @decapode begin
+#  h::Form0
+#  (Γ,n)::Constant
+#
+#  ḣ == ∂ₜ(h)
+#  #ḣ == -1 * Γ * ∘(⋆, d, ⋆)(d(h) .* abs(d(h))^(n-1) .* avg₀₁(h^(n+2)))
+#  ḣ == Γ * ∘(⋆, d, ⋆)(d(h) .* abs(d(h))^(n-1) .* avg₀₁(h^(n+2)))
+#  #ḣ == ∘(⋆, d, ⋆)(Γ * avg₀₁(h^(n+2)) .* abs(d(h))^(n-1) .* d(h))
+#end
+#
+## Equation 1 from Glen, J. W. THE FLOW LAW OF ICE: A discussion of the
+## assumptions made in glacier theory, their experimental foundations and
+## consequences. (1958)
+#glen_eq1 = @decapode begin
+#  (ϵ,σ,A,n)::Constant
+#
+#  ϵ == (σ/A)^n
+#end
+#
+## Equation 1 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF ICE
+## SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
+#mahaffy_eq1 = @decapode begin
+#  h::Form0
+#  (ϵ,σ,A,n)::Constant
+#  b::Parameter
+#
+#  ḣ == ∂ₜ(h)
+#  ḣ == b - ∘(⋆, d, ⋆)(q)
+#end
+#
+## Equations 9 and 10 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF
+## ICE SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
+#mahaffy_eqs9_10 = @decapode begin
+#  h::Form0
+#  (σ,ρ,g)::Constant
+#
+#  σ == -ρ * g * (h-z) * d(h)
+#end
+#
+## Equation 13 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF ICE
+## SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
+#mahaffy_eq13 = @decapode begin
+#  h::Form0
+#  α::Form1
+#
+#  α == abs(d(h))
+#end
+#
+## Equations 14 and 15 from Mahaffy, M. W. A THREE-DIMENSIONAL NUMERICAL MODEL OF
+## ICE SHEETS: Tests on the Barnes ICe Cap, Northwest Territories. (1976)
+#mahaffy_eqs14_15 = @decapode begin
+#  h::Form0
+#  (α,q)::Form1
+#
+#end
+## Infer the forms of dependent variables, and resolve which versions of DEC
+## operators to use.
+#halfar = expand_operators(halfar_eq1)
+#infer_types!(expand_operators(ice_dynamics))
+#resolve_overloads!(ice_dynamics)
+#infer_types!(halfar, op1_inf_rules_2D,
+#  vcat(op2_inf_rules_2D, [
+#    (proj1_type = :Constant, proj2_type = :Literal, res_type = :Constant, op_names = [:/, :./, :*, :.*]),
+#    (proj1_type = :Literal, proj2_type = :Constant, res_type = :Constant, op_names = [:/, :./, :*, :.*])]
+#  ))
+#resolve_overloads!(halfar)
+#
+## Visualize.
+#to_graphviz(halfar)
+#to_graphviz(ice_dynamics)
+#constants_and_parameters = (
+#  n = n,
+#  ρ = ρ,
+#  g = g,
+#  A = A,
+#  Γ = Γ)
+#prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+#soln = solve(prob, Tsit5())
+#extrema(findnode(soln(0.0), :h))
+#extrema(findnode(soln(tₑ ), :h))
+#
+#extrema(d0s * findnode(soln(0.0), :h))
+#extrema(d0s * findnode(soln(tₑ ), :h))
+
+#sim = eval(gensim(halfar, dimension=2))
+#fₘ = sim(s, generate)
+#@save "halfar.jld2" soln
+#begin # BEGIN Gif creation
+#frames = 100
+## Initial frame
+##fig = GLMakie.Figure(resolution = (400, 400))
+#fig, ax, ob = GLMakie.mesh(s′, color=findnode(soln(0), :h), colormap=:jet, colorrange=extrema(findnode(soln(tₑ), :h)))
+#Colorbar(fig[1,2], ob)
+#
+## Animation
+#record(fig, "halfar.gif", range(0.0, tₑ; length=frames); framerate = 30) do t
+#    ob.color = findnode(soln(t), :h)
+#end
+#
+#end # END Gif creation

--- a/examples/climate/shallow_ice.jl
+++ b/examples/climate/shallow_ice.jl
@@ -21,20 +21,20 @@ Point2D = Point2{Float64}
 
 # Equation 2 from Halfar, P. ON THE DYNAMICS OF THE ICE SHEETS. (1981)
 halfar_eq2 = @decapode begin
-  (h,Γ)::Form0
+  h::Form0
+  Γ::Form1
   n::Constant
 
   ḣ == ∂ₜ(h)
-  ḣ == ∘(⋆, d, ⋆)(Γ .* d(h) .* abs(d(h))^(n-1) .* avg₀₁(h^(n+2)))
+  ḣ == ∘(⋆, d, ⋆)(Γ * d(h) * avg₀₁(mag(♯(d(h)))^(n-1)) * avg₀₁(h^(n+2)))
 end
-to_graphviz(halfar_eq2)
 
 # Equation 1 from Glen, J. W. THE FLOW LAW OF ICE: A discussion of the
 # assumptions made in glacier theory, their experimental foundations and
 # consequences. (1958)
 glens_law = @decapode begin
-  Γ::Form0
-  (A,ρ,g,n)::Constant
+  (A, Γ)::Form1
+  (ρ,g,n)::Constant
   
   Γ == (2/(n+2))*A*(ρ*g)^n
 end

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -423,22 +423,19 @@ function infer_summands_and_summations!(d::SummationDecapode)
 
     known_types = types[findall(!=(:infer), types)]
     if :Literal ∈ known_types
-      # If anything is a Literal, then anything not inferred is a constant.
+      # If anything is a Literal, then anything not inferred is a Constant.
       inferred_type = :Constant
-      to_infer_idxs = filter(i -> d[:type][i] == :infer, idxs)
-      d[to_infer_idxs, :type] = inferred_type
-    elseif !isnothing(findfirst(x -> x != :Constant && x != :infer, types))
-      # If anything is a Form, then any term in this sum is the same Form.
+    elseif !isnothing(findfirst(!=(:Constant), known_types))
+      # If anything is a Form, then any term in this sum is the same kind of Form.
       # Note that we are not explicitly changing Constants to Forms here,
       # although we should consider doing so.
-      to_infer_idxs = filter(i -> d[:type][i] == :infer, idxs)
-      d[to_infer_idxs, :type] = inferred_type
+      inferred_type = findfirst(!=(:Constant), known_types)
     else
-      # All terms are now either Constant or infer. Set them all to Constant.
-      inferred_type = types[findfirst(!=(:infer), types)]
-      to_infer_idxs = filter(i -> d[:type][i] == :infer, idxs)
-      d[to_infer_idxs, :type] = inferred_type
+      # All terms are now a mix of Constant or infer. Set them all to Constant.
+      inferred_type = :Constant
     end
+    to_infer_idxs = filter(i -> d[:type][i] == :infer, idxs)
+    d[to_infer_idxs, :type] = inferred_type
     applied = true
   end
   return applied
@@ -461,10 +458,6 @@ function infer_types!(d::SummationDecapode, op1_rules::Vector{NamedTuple{(:src_t
   types_known_op1 = ones(Bool, nparts(d, :Op1))
   types_known_op1[incident(d, :infer, [:src, :type])] .= false
   types_known_op1[incident(d, :infer, [:tgt, :type])] .= false
-
-  #types_known_op1 = zeros(Bool, nparts(d, :Op1))
-  #types_known_op1[incident(d, :infer, [:src, :type])] .= false
-  #types_known_op1[incident(d, :infer, [:tgt, :type])] .= false
 
   types_known_op2 = zeros(Bool, nparts(d, :Op2))
   types_known_op2[incident(d, :infer, [:proj1, :type])] .= false

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -349,12 +349,22 @@ op2_inf_rules_2D = vcat(op2_inf_rules_1D, [
   (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, op_names = [:∧, :∧₂₀]),
   (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, op_names = [:∧, :∧₀₂]),
 
+  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:L]),    
+
   # Rules for L₂
   (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form2, op_names = [:L, :L₂]),    
 
   # Rules for i₁
   (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form1, op_names = [:i, :i₁]),
   
+  # Rules for subtraction
+  (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, op_names = [:-, :.-]),
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, op_names = [:-, :.-]),
+  (proj1_type = :Form2, proj2_type = :Form2, res_type = :Form2, op_names = [:-, :.-]),
+  (proj1_type = :DualForm0, proj2_type = :DualForm0, res_type = :DualForm0, op_names = [:-, :.-]),
+  (proj1_type = :DualForm1, proj2_type = :DualForm1, res_type = :DualForm1, op_names = [:-, :.-]),
+  (proj1_type = :DualForm2, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:-, :.-]),
+
   # Rules for divison and multiplication
   (proj1_type = :Form2, proj2_type = :Form2, res_type = :Form2, op_names = [:./, :.*]),
   (proj1_type = :Literal, proj2_type = :Form2, res_type = :Form2, op_names = [:/, :./, :*, :.*]),
@@ -569,6 +579,7 @@ op2_res_rules_2D = vcat(op2_res_rules_1D, [
   (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, resolved_name = :∧₀₂, op = :∧),
   # Rules for L.
   (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form2, resolved_name = :L₂, op = :L),
+  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, resolved_name = :L₂ᵈ, op = :L),
   # Rules for i.
   (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form1, resolved_name = :i₂, op = :i)])
   

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -427,11 +427,10 @@ function infer_summands_and_summations!(d::SummationDecapode)
       inferred_type = :Constant
       to_infer_idxs = filter(i -> d[:type][i] == :infer, idxs)
       d[to_infer_idxs, :type] = inferred_type
-    elseif findfirst(x -> x != :Constant || x != :infer)
+    elseif !isnothing(findfirst(x -> x != :Constant && x != :infer, types))
       # If anything is a Form, then any term in this sum is the same Form.
       # Note that we are not explicitly changing Constants to Forms here,
       # although we should consider doing so.
-      inferred_type = types[findfirst(x -> x != :Constant || x != :infer)]
       to_infer_idxs = filter(i -> d[:type][i] == :infer, idxs)
       d[to_infer_idxs, :type] = inferred_type
     else

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -429,7 +429,7 @@ function infer_summands_and_summations!(d::SummationDecapode)
       # If anything is a Form, then any term in this sum is the same kind of Form.
       # Note that we are not explicitly changing Constants to Forms here,
       # although we should consider doing so.
-      inferred_type = findfirst(!=(:Constant), known_types)
+      inferred_type = known_types[findfirst(!=(:Constant), known_types)]
     else
       # All terms are now a mix of Constant or infer. Set them all to Constant.
       inferred_type = :Constant

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -211,7 +211,6 @@ function compile_env(d::AbstractNamedDecapode, dec_matrices::Vector{Symbol})
   end
 
 function compile_var(alloc_vectors::Vector{AllocVecCall})
-    #return quote $(map(Expr, alloc_vectors)...) end
     return quote $(Expr.(alloc_vectors)...) end
 end
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -211,7 +211,8 @@ function compile_env(d::AbstractNamedDecapode, dec_matrices::Vector{Symbol})
   end
 
 function compile_var(alloc_vectors::Vector{AllocVecCall})
-    return quote $(map(Expr, alloc_vectors)...) end
+    #return quote $(map(Expr, alloc_vectors)...) end
+    return quote $(Expr.(alloc_vectors)...) end
 end
 
 # This is the block of parameter setting inside f

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -338,6 +338,13 @@ function compile(d::SummationDecapode, inputs::Vector, dec_matrices::Vector{Symb
 
                 end
 
+                if(operator == :(*))
+                    operator = promote_arithmetic_map[operator]
+                end
+                if(operator == :(-))
+                    operator = promote_arithmetic_map[operator]
+                end
+
                 visited_2[op] = true
                 visited_Var[r] = true
                 c = BinaryCall(operator, equality, a1name, a2name, rname)
@@ -362,6 +369,8 @@ function compile(d::SummationDecapode, inputs::Vector, dec_matrices::Vector{Symb
                     equality = promote_arithmetic_map[equality]
                     push!(alloc_vectors, AllocVecCall(rname, d[r, :type], dimension))
                 end
+
+                operator = :(.+)
 
                 visited_Σ[op] = true
                 visited_Var[r] = true

--- a/test/diag2dwd.jl
+++ b/test/diag2dwd.jl
@@ -664,6 +664,28 @@ end
   names_types_expected_15 = Set([(:A, :Form1), (:B, :Form2), (:C, :Form1)])
   @test issetequal(names_types_15, names_types_expected_15)
 
+  # Special case of a summation where all is infer, but a single Literal.
+  t16 = @decapode begin
+    A == 2 + C + D
+  end
+  infer_types!(t16)
+
+  names_types_16 = get_name_type_pair(t16)
+  names_types_expected_16 = Set([(:A, :Constant), (:C, :Constant), (:D, :Constant), (Symbol("2"), :Literal)])
+  @test issetequal(names_types_16, names_types_expected_16)
+
+  # Special case of a summation where all is infer, but a single Literal.
+  t17 = @decapode begin
+    A::Form0
+    C::Constant
+    A == C + D
+  end
+  infer_types!(t17)
+
+  names_types_17 = get_name_type_pair(t17)
+  names_types_expected_17 = Set([(:A, :Form0), (:C, :Constant), (:D, :Form0)])
+  @test issetequal(names_types_17, names_types_expected_17)
+
 end
 
 @testset "Overloading Resolution" begin

--- a/test/diag2dwd.jl
+++ b/test/diag2dwd.jl
@@ -664,7 +664,7 @@ end
   names_types_expected_15 = Set([(:A, :Form1), (:B, :Form2), (:C, :Form1)])
   @test issetequal(names_types_15, names_types_expected_15)
 
-  # Special case of a summation where all is infer, but a single Literal.
+  # Special case of a summation with a mix of infer and Literal.
   t16 = @decapode begin
     A == 2 + C + D
   end
@@ -674,7 +674,7 @@ end
   names_types_expected_16 = Set([(:A, :Constant), (:C, :Constant), (:D, :Constant), (Symbol("2"), :Literal)])
   @test issetequal(names_types_16, names_types_expected_16)
 
-  # Special case of a summation where all is infer, but a single Literal.
+  # Special case of a summation with a mix of Form, Constant, and infer.
   t17 = @decapode begin
     A::Form0
     C::Constant
@@ -685,6 +685,17 @@ end
   names_types_17 = get_name_type_pair(t17)
   names_types_expected_17 = Set([(:A, :Form0), (:C, :Constant), (:D, :Form0)])
   @test issetequal(names_types_17, names_types_expected_17)
+
+  # Special case of a summation with a mix of infer and Constant.
+  t18 = @decapode begin
+    C::Constant
+    A == C + D
+  end
+  infer_types!(t18)
+
+  names_types_18 = get_name_type_pair(t18)
+  names_types_expected_18 = Set([(:A, :Constant), (:C, :Constant), (:D, :Constant)])
+  @test issetequal(names_types_18, names_types_expected_18)
 
 end
 


### PR DESCRIPTION
This PR introduces an ice model based on Halfar's "On the Dynamics of Ice Sheets". (1981).

We also update the Budyko-Sellers model to demonstrate composition.

There is also a fix to type inference of summations in this PR.

# Equation 2 from Halfar's "On the Dynamics of Ice Sheets". (1981).
![image](https://github.com/AlgebraicJulia/Decapodes.jl/assets/70283489/70b1e858-f691-4d14-bf81-ef5d1a500efb)

# Ice Dynamics Diagram Generated From Above Equation
![ice_dynamics](https://github.com/AlgebraicJulia/Decapodes.jl/assets/70283489/20d8b2df-c038-41d7-aa47-010da74af57b)

# Glacial Flow Auto-Generated From Above Diagram
Ice height is initialized as an upwards parabola centered at (0,0). 
![ice_dynamics](https://github.com/AlgebraicJulia/Decapodes.jl/assets/70283489/27180364-0d46-4544-a008-daf848b186c4)
