### PR TITLE
Do not aggressively apply dot

### DIFF
--- a/src/Decapodes.jl
+++ b/src/Decapodes.jl
@@ -15,7 +15,7 @@ using Base.Iterators
 import Unicode
 
 export normalize_unicode, DerivOp, append_dot,
-  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!, op1_inf_rules_1D, op2_inf_rules_1D, op1_inf_rules_2D, op2_inf_rules_2D, op1_res_rules_1D, op2_res_rules_1D, op1_res_rules_2D, op2_res_rules_2D,
+  SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, Decapode, NamedDecapode, SummationDecapode, fill_names!, dot_rename!, expand_operators, add_constant!, add_parameter, infer_types!, resolve_overloads!, op1_inf_rules_1D, op2_inf_rules_1D, op1_inf_rules_2D, op2_inf_rules_2D, op1_res_rules_1D, op2_res_rules_1D, op1_res_rules_2D, op2_res_rules_2D,
   Term, Var, Judgement, Eq, AppCirc1, AppCirc2, App1, App2, Plus, Tan, term, parse_decapode,
   VectorForm, PhysicsState, findname, findnode,
   compile, compile_env, gensim, evalsim, closest_point, flat_op,

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -47,10 +47,31 @@ function fill_names!(d::AbstractNamedDecapode)
   for e in incident(d, :∂ₜ, :op1)
     s = d[e,:src]
     t = d[e, :tgt]
+    String(d[t,:name])[1] != '•' && continue
     d[t, :name] = append_dot(d[s,:name])
   end
-  return d
+  d
 end
+
+"""    dot_rename!(d::AbstractNamedDecapode)
+
+Rename tangent variables by their depending variable appended with a dot.
+e.g. If D == ∂ₜ(C), then rename D to Ċ.
+
+If a tangent variable updates multiple vars, choose one arbitrarily.
+e.g. If D == ∂ₜ(C) and D == ∂ₜ(B), then rename D to either Ċor  B ̇.
+"""
+function dot_rename!(d::AbstractNamedDecapode)
+  # TODO: This method only works because higher order derivatives have always
+  # appeared later in the Var table.
+  for e in incident(d, :∂ₜ, :op1)
+    s = d[e,:src]
+    t = d[e, :tgt]
+    d[t, :name] = append_dot(d[s,:name])
+  end
+  d
+end
+
 
 function make_sum_mult_unique!(d::AbstractNamedDecapode)
   snum = 1

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -81,7 +81,7 @@ Rename tangent variables by their depending variable appended with a dot.
 e.g. If D == ∂ₜ(C), then rename D to Ċ.
 
 If a tangent variable updates multiple vars, choose one arbitrarily.
-e.g. If D == ∂ₜ(C) and D == ∂ₜ(B), then rename D to either Ċor  B ̇.
+e.g. If D == ∂ₜ(C) and D == ∂ₜ(B), then rename D to either Ċ or B ̇.
 """
 function dot_rename!(d::AbstractNamedDecapode)
   dep, order = find_dep_and_order(d)

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -335,7 +335,7 @@ Test8Res = average_rewrite(Test8)
 Test8Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Var = 3
   type = Any[:Form1, :Form2, :Form0]
-  name = [:D₁, :D₂, :D₁̇ ]
+  name = [:D₁, :D₂, :F]
 
   TVar = 1
   incl = [3]


### PR DESCRIPTION
Close #134 

Currently, when constructing Decapodes, tangent variables are always renamed as the variable they depend on appended with a dot.
E.g. `D == \partial\_t(C)` creates a Decapode with two variables named `C\dot` and `C`.

This strategy was chosen by default since users sometimes only describe TVars in terms of their relation to other quantities. E.g. in `\partial\_t(Foo) == Bar(Buzz)`, the quantity `\partial\_t(Foo)` is never given a human-legible name. So defaulting to `Foo\dot` is appropriate.

This is, of course, always fine from a compilation aspect, since the generated program is name-agnostic.

But, this can seriously impact usability. If a user has created a Decapode, and has given a TVar a human-readable name, then they expect to be able to refer to the TVar by that when trying to compose with it.

It should be noted that renaming variables using the append-dot method is an example of where we can make physical systems more legible through analysis of a Decapode. In other words, we can perform some rewriting to tell the user that a variable is a first, second, or higher-order derivative. Users in practice essentially must traverse the TVar table to glean this information themselves. If done elegantly, this exemplifies the automation of physical intuition that we often aim for. If done inelegantly - by renaming too aggressively - we confuse the reader when they try to compose Decapodes.

So, in this PR, we default to using human-legible variable names when provided, and only rename with dots when no name is available. We also offer a function that aggressively performs renaming that the user can call on-demand.