### PR TITLE
Add Fokker-Planck Decapode

### DIFF
--- a/examples/chemistry/fokker_planck.jl
+++ b/examples/chemistry/fokker_planck.jl
@@ -1,0 +1,67 @@
+# We use here the formulation studied by Jordan, Kinderlehrer, and Otto in "The
+# Variational Formulation of the Fokker-Planck Equation" (1996).
+
+# The formualation they studied is that where the drift coefficient is the
+# gradient of (some potential) Ψ.
+
+# Load libraries.
+using Catlab, CombinatorialSpaces, Decapodes
+using GLMakie, LinearAlgebra, MLStyle, MultiScaleArrays, OrdinaryDiffEq
+
+# Specify physics.
+Fokker_Planck = @decapode begin
+  (ρ,Ψ)::Form0
+  β⁻¹::Constant
+  ∂ₜ(ρ) == ∘(⋆,d,⋆)(d(Ψ)∧ρ) + β⁻¹*Δ(ρ)
+end
+
+Fokker_Planck = expand_operators(Fokker_Planck)
+infer_types!(Fokker_Planck)
+resolve_overloads!(Fokker_Planck)
+
+# Specify domain.
+include("../grid_meshes.jl")
+include("examples/grid_meshes.jl")
+s′ = triangulated_grid(1,1,0.05,0.05,Point3D)
+s = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s′)
+subdivide_duals!(s, Barycenter())
+
+# Specify initial conditions.
+Ψ = map(p -> √(2)/2 - √((p[1]-.5)^2 + (p[2]-.5)^2) , point(s))
+ρ = fill(1 / sum(s[:area]), nv(s))
+constants_and_parameters = (β⁻¹ = 0.001,)
+u₀ = construct(PhysicsState, [VectorForm(Ψ), VectorForm(ρ)], Float64[], [:Ψ, :ρ])
+
+# Compile.
+function generate(sd, my_symbol; hodge=GeometricHodge())
+  op = @match my_symbol begin
+    _ => default_dec_generate(sd, my_symbol)
+  end
+  return (args...) ->  op(args...)
+end
+sim = eval(gensim(Fokker_Planck))
+fₘ = sim(s, generate)
+
+# Run.
+tₑ = 1.0
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+
+# Save solution data.
+@save "fokker_planck.jld2" soln
+
+# Create GIF
+begin
+frames = 800
+# Initial frame
+fig = CairoMakie.Figure(resolution = (800, 800))
+p1 = CairoMakie.mesh(fig[1,1], s′, color=findnode(soln(0), :ρ), colormap=:jet, colorrange=extrema(findnode(soln(0), :ρ)))
+Colorbar(fig[1,2], colormap=:jet, colorrange=extrema(findnode(soln(0), :U)))
+
+# Animation
+record(fig, "fokker_planck.gif", range(0.0, tₑ; length=frames); framerate = 30) do t
+    p1.plot.color = findnode(soln(t), :ρ)
+end
+
+end
+


### PR DESCRIPTION
There is growing interest in supporting stochastic differential equations in the Decapodes framework.

Although directly supporting such equations will require further work, we can for the time being look at some ordinary and partial differential equations that are closely related to such. (For the relation between SDEs and Fokker-Planck, see the Wikipedia write-up.)

So, we introduce here the Fokker-Planck Decapode. In particular, we use the formulation given by Jordan, Kinderlehrer, and Otto in "The Variational Formulation of the Fokker-Planck Equation" (1996) [0]. This formulation is nice due to its plain notation, and clear exposition in the rest of the document.

![IMG_0624](https://github.com/AlgebraicJulia/Decapodes.jl/assets/70283489/25e75926-42c4-461c-9e5a-bdb7a2b84f53)
![IMG_0623](https://github.com/AlgebraicJulia/Decapodes.jl/assets/70283489/d2772261-8544-494c-9f14-a6441bf2c9bc)


The Focker-Planck Equation itself is particularly well-suited to this framework for reasons explained by Garrido in their “ON THE COVARIANCE OF THE FOKKER-PLANCK EQUATION” (1979) [1]. Graham’s “Covariant Formulation of Non-Equilibrium Statistical Thermodynamics” (1976) [2] provides a some background justifications for Garrido’s work, but I have not been able to read to deeply into this paper yet.

This Decapode ought to be refactored such that one composes with a Drift (or Jordan) Decapode - that defines drift as the gradient of Psi - with a Fokker-Planck Decapode - that defines drift as merely a 1-Form - to produce the Jordan-Fokker-Planck Decapode. This is for the usual reason of using composition to make explicit some assumption made in a model.

### References
GitHub might replace these with hyperlinks.
[0]: https://francahoffmann.files.wordpress.com/2018/07/302ca7465ae824f3d2d629bfeaacfb56b4b8.pdf
[1]: https://www.sciencedirect.com/science/article/abs/pii/0378437180901557
[2]: https://www.semanticscholar.org/paper/Covariant-formulation-of-non-equilibrium-Graham/ba7dabb057ac972df2787e5fdcce53b9be8720ad