### PR TITLE
Fix automatic differentiation of simulation and allow setting u-type cache

### DIFF
--- a/examples/climate/budyko_sellers.jl
+++ b/examples/climate/budyko_sellers.jl
@@ -204,8 +204,9 @@ prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
 soln = solve(prob, Tsit5())
 @show soln.retcode
 @info("Done")
-
 @save "budyko_sellers.jld2" soln
+
+soln = solve(prob, FBDF())
 
 #############
 # Visualize #

--- a/src/Decapodes.jl
+++ b/src/Decapodes.jl
@@ -11,6 +11,7 @@ using Catlab.ACSetInterface
 using LinearAlgebra
 using MLStyle
 using Base.Iterators
+using PreallocationTools
 
 import Unicode
 


### PR DESCRIPTION
This fixes automatic differentiation, thus allowing implicit methods to be used. Also, this allows for setting the u-type for the caches, thus allowing for automatic differentiation of the solve itself for gradient-based optimization. Demonstrations of use cases will follow, but for now I have added a test showing that implicit methods work and the u-type stuff has been demonstrated locally.
