### PR TITLE
Remove Catlab.Theories imports

### DIFF
--- a/src/Decapodes.jl
+++ b/src/Decapodes.jl
@@ -2,7 +2,6 @@ module Decapodes
 
 using Catlab
 using Catlab.Theories
-import Catlab.Theories: otimes, oplus, compose, ⊗, ⊕, ⋅, associate, associate_unit, Ob, Hom, dom, codom
 using Catlab.Programs
 using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams

--- a/test/diag2dwd.jl
+++ b/test/diag2dwd.jl
@@ -1,7 +1,6 @@
 using Test
 using Catlab
 using Catlab.Theories
-import Catlab.Theories: otimes, oplus, compose, ⊗, ⊕, ⋅, associate, associate_unit, Ob, Hom, dom, codom
 using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams
 using Catlab.WiringDiagrams.DirectedWiringDiagrams


### PR DESCRIPTION
Anyone who uses `LinearAlgebra` and `Catlab` will receive a warning about `\cdot` being defined by both packages.

The particular warning generated by `Decapodes` in issue #157 can be avoided by removing some unnecessary `import`s from `Catlab.Theories`.