### PR TITLE
InterTypes for the Decapode ACSet

### DIFF
--- a/src/decapodeacset.it
+++ b/src/decapodeacset.it
@@ -1,0 +1,42 @@
+@schema SchDecapode(FreeSchema) begin
+    (Var, TVar, Op1, Op2)::Ob
+    (Type, Operator)::AttrType(Symbol)
+    src::Hom(Op1, Var)
+    tgt::Hom(Op1, Var)
+    proj1::Hom(Op2, Var)
+    proj2::Hom(Op2, Var)
+    res::Hom(Op2, Var)
+    incl::Hom(TVar, Var)
+    
+    op1::Attr(Op1, Operator)
+    op2::Attr(Op2, Operator)
+    type::Attr(Var, Type)
+end
+
+@schema SchNamedDecapode <: SchDecapode begin
+    Name::AttrType(Symbol)
+    name::Attr(Var, Name)
+end
+
+@abstract_acset_type AbstractDecapode
+@abstract_acset_type AbstractNamedDecapode <: AbstractDecapode
+
+@acset_type Decapode(SchDecapode,
+  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]) <: AbstractDecapode
+
+@acset_type NamedDecapode(SchNamedDecapode,
+  index=[:src, :tgt, :res, :incl, :op1, :op2, :type, :name]) <: AbstractNamedDecapode
+
+@schema SchSummationDecapode <: SchNamedDecapode begin
+  # Σ are the white nodes in the Decapode drawing
+  # Summands are the edges that connect white nodes to variables (the projection maps)
+  # because addition is commutative, we don't need to distinguish the order
+  (Σ, Summand)::Ob
+  summand::Hom(Summand, Var)
+  summation::Hom(Summand, Σ)
+  sum::Hom(Σ, Var)
+end
+
+@acset_type SummationDecapode(SchSummationDecapode,
+  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]) <: AbstractNamedDecapode
+

--- a/src/decapodeacset.it
+++ b/src/decapodeacset.it
@@ -1,4 +1,4 @@
-@schema SchDecapode(FreeSchema) begin
+@schema SchDecapode begin
     (Var, TVar, Op1, Op2)::Ob
     (Type, Operator)::AttrType(Symbol)
     src::Hom(Op1, Var)
@@ -21,11 +21,17 @@ end
 @abstract_acset_type AbstractDecapode
 @abstract_acset_type AbstractNamedDecapode <: AbstractDecapode
 
-@acset_type Decapode(SchDecapode,
-  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]) <: AbstractDecapode
+@acset_type SymDecapode(
+  SchDecapode,
+  generic=Decapode,
+  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]
+) <: AbstractDecapode
 
-@acset_type NamedDecapode(SchNamedDecapode,
-  index=[:src, :tgt, :res, :incl, :op1, :op2, :type, :name]) <: AbstractNamedDecapode
+@acset_type SymNamedDecapode(
+  SchNamedDecapode,
+  generic = NamedDecapode,
+  index=[:src, :tgt, :res, :incl, :op1, :op2, :type, :name]
+) <: AbstractNamedDecapode
 
 @schema SchSummationDecapode <: SchNamedDecapode begin
   # Σ are the white nodes in the Decapode drawing
@@ -37,6 +43,9 @@ end
   sum::Hom(Σ, Var)
 end
 
-@acset_type SummationDecapode(SchSummationDecapode,
-  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]) <: AbstractNamedDecapode
+@acset_type SymSummationDecapode(
+  SchSummationDecapode,
+  generic = SummationDecapode,
+  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]
+) <: AbstractNamedDecapode
 

--- a/src/decapodeacset.jl
+++ b/src/decapodeacset.jl
@@ -2,35 +2,11 @@ using Catlab
 using Catlab.Theories: FreeSchema
 using Catlab.DenseACSets
 using DataStructures
+using ACSets.InterTypes
 
-@present SchDecapode(FreeSchema) begin
-    (Var, TVar, Op1, Op2)::Ob
-    (Type, Operator)::AttrType
-    src::Hom(Op1, Var)
-    tgt::Hom(Op1, Var)
-    proj1::Hom(Op2, Var)
-    proj2::Hom(Op2, Var)
-    res::Hom(Op2, Var)
-    incl::Hom(TVar, Var)
-    
-    op1::Attr(Op1, Operator)
-    op2::Attr(Op2, Operator)
-    type::Attr(Var, Type)
-end
+@intertypes "decapodeacset.it" module decapodeacset end
 
-@present SchNamedDecapode <: SchDecapode begin
-    Name::AttrType
-    name::Attr(Var, Name)
-end
-
-@abstract_acset_type AbstractDecapode
-@abstract_acset_type AbstractNamedDecapode <: AbstractDecapode
-
-@acset_type Decapode(SchDecapode,
-  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]) <: AbstractDecapode
-
-@acset_type NamedDecapode(SchNamedDecapode,
-  index=[:src, :tgt, :res, :incl, :op1, :op2, :type, :name]) <: AbstractNamedDecapode
+using .decapodeacset
 
 """    fill_names!(d::AbstractNamedDecapode)
 
@@ -153,19 +129,6 @@ function expand_operators!(e::AbstractNamedDecapode, d::AbstractNamedDecapode)
   end
   return newvar
 end
-
-@present SchSummationDecapode <: SchNamedDecapode begin
-  # Σ are the white nodes in the Decapode drawing
-  # Summands are the edges that connect white nodes to variables (the projection maps)
-  # because addition is commutative, we don't need to distinguish the order
-  (Σ, Summand)::Ob
-  summand::Hom(Summand, Var)
-  summation::Hom(Summand, Σ)
-  sum::Hom(Σ, Var)
-end
-
-@acset_type SummationDecapode(SchSummationDecapode,
-  index=[:src, :tgt, :res, :incl, :op1, :op2, :type]) <: AbstractNamedDecapode
 
 
 """    function expand_operators(d::SummationDecapode)


### PR DESCRIPTION
Define the decapode acsets via an intertype file, so that the intertypes can be used later down the line in SyntacticModels.