### PR TITLE
Fixed problems with Constant typing

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -252,8 +252,8 @@ function compile(d::SummationDecapode, inputs::Vector, alloc_vectors::Vector{All
   visited_2 = falses(nparts(d, :Op2))
   visited_Σ = falses(nparts(d, :Σ))
 
-  promote_arithmetic_map = Dict(:(+) => :.+, :(-) => :.-, :(*) => :.*, :(/) => :./, :(=) => :.=,
-                                :.+ => :.+, :.- => :.-, :.* => :.*, :./ => :./, :.= => :.=)
+  promote_arithmetic_map = Dict(:(+) => :.+, :(-) => :.-, :(*) => :.*, :(/) => :./, :(^) => :.^, :(=) => :.=,
+                                :.+ => :.+, :.- => :.-, :.* => :.*, :./ => :./, :.^ => :.^, :.= => :.=)
 
   # FIXME: this is a quadratic implementation of topological_sort inlined in here.
   op_order = []
@@ -339,6 +339,10 @@ end =#
         if(operator == :(-))
           operator = promote_arithmetic_map[operator]
         end
+        if(operator == :(^))
+          operator = promote_arithmetic_map[operator]
+        end
+
 
         visited_2[op] = true
         visited_Var[r] = true

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -151,7 +151,7 @@ add_inplace_stub(var_name::Symbol) = add_stub(gensim_in_place_stub, var_name)
 
 # This will be the function and matrix generation
 function compile_env(d::AbstractNamedDecapode, dec_matrices::Vector{Symbol}, con_dec_operators::Set{Symbol})
-  assumed_ops = Set([:+, :*, :-, :/, :.+, :.*, :.-, :./])
+  assumed_ops = Set([:+, :*, :-, :/, :.+, :.*, :.-, :./, :^, :.^])
   defined_ops = Set()
 
   defs = quote end
@@ -499,6 +499,7 @@ function gensim(user_d::AbstractNamedDecapode, input_vars; dimension::Int=2,
   tars = set_tanvars_code(d′)
 
   # We need to run this after we grab the constants and parameters out
+  infer_overload_compiler!(d′, dimension)
   resolve_types_compiler!(d′)
   infer_overload_compiler!(d′, dimension)
 


### PR DESCRIPTION
Added a new infer/resolve cycle before changing to compiler types. Also added exponents to the assumed _ops, letting Julia define this operation itself without need for a generate function entry. Fixes issue #221.