### PR TITLE
In generating simulate, return nothing, for Enzyme compatibility

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -571,6 +571,7 @@ function gensim(user_d::AbstractNamedDecapode, input_vars; dimension::Int=2, sta
         $vars
         $(equations...)
         $(tars...)
+        return nothing
       end;
     end
   end


### PR DESCRIPTION
Enzyme expects these functions to return `nothing` to be autodiffable. Is this ok?