### PR TITLE
change getproperty to setproperty! in simulation

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -354,7 +354,7 @@ is the name of the variable whose data will be stored and a code target.
 """
 function hook_STC_settvar(state_name::Symbol, tgt_name::Symbol, ::Union{CPUBackend, CUDABackend})
   ssymb = QuoteNode(state_name)
-  return :(getproperty(du, $ssymb) .= $tgt_name)
+  return :(setproperty!(du, $ssymb, $tgt_name))
 end
 
 const PROMOTE_ARITHMETIC_MAP = Dict(:(+) => :.+,


### PR DESCRIPTION
Advantages:
This works whether the component you want to change in a ComponentArray/NamedTuple is an array or not,
e.g. you can have `p = ComponentArray(k= 1.0)` or `p = ComponentArray(k = [1.0])` and it should work. 