### PR TITLE
Use traversal abstraction

### DIFF
--- a/test/simulation_core.jl
+++ b/test/simulation_core.jl
@@ -13,7 +13,7 @@ const DOT_EQUALS =:.=
 # Calling Code Tests #
 ######################
 
-import Decapodes: UnaryCall, add_inplace_stub
+import Decapodes: UnaryCall, inplace
 
 @testset "Test UnaryCall" begin
   # Test equality, basic operator
@@ -34,7 +34,7 @@ import Decapodes: UnaryCall, add_inplace_stub
   @test Expr(UnaryCall(:.-, DOT_EQUALS, :x, :y)) == :(y .= .-x)
 
   # Test broadcast equality, inplace non-matrix method
-  let inplace_op = add_inplace_stub(:⋆₁⁻¹)
+  let inplace_op = inplace(:⋆₁⁻¹)
     @test Expr(UnaryCall(inplace_op, DOT_EQUALS, :x, :y)) == :($inplace_op(y, x))
   end
 end
@@ -46,7 +46,7 @@ import Decapodes: BinaryCall
   @test Expr(BinaryCall(:F, EQUALS, :x, :y, :z)) == :(z = F(x, y))
 
   # Test broadcast equality, inplace operator
-  let inplace_operator = add_inplace_stub(:F)
+  let inplace_operator = inplace(:F)
     @test Expr(BinaryCall(inplace_operator, DOT_EQUALS, :x, :y, :z)) == :($inplace_operator(z, x, y))
   end
 end


### PR DESCRIPTION
DiagrammaticEquations.jl PRs [69](https://github.com/AlgebraicJulia/DiagrammaticEquations.jl/pull/69) and [70](https://github.com/AlgebraicJulia/DiagrammaticEquations.jl/pull/70) demonstrate means of traversing a SummationDecapode object, and returning a cached record of topologically-sorted operations.

This current PR demonstrates how this means can be used to re-organize code which “visits” such operations and emits code. For the purposes of this PR, whether DiagrammaticEquations returns a (lazy) iterator over a SummationDecapode or a collected version of such is abstracted away.

It also takes the opportunity to make minor modifications to the rules around when certain operations can be broadcasted.

Tests pass using commit dfe0e03 of DiagrammaticEquations’ `llm/fw` branch.