### PR TITLE
Add keyword argument for contract operators, clean simulation pipeline

### DIFF
--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -325,15 +325,12 @@ end
 
 @testset "Gensim Transformations" begin
 
-  function checkForContractionInGensim(d::SummationDecapode)
-    results = []
-    block = gensim(d).args[2].args[2].args[5]
-    for line in 2:length(block.args)
-      push!(results, block.args[line].args[1])
-    end
-
-    return results
+  function count_contractions(e::Expr)
+    block = e.args[2].args[2].args[5]
+    length(block.args) - 1
   end
+
+  count_contractions(d::SummationDecapode) = count_contractions(gensim(d))
 
   begin
     primal_earth = loadmesh(Icosphere(1))
@@ -376,7 +373,9 @@ end
     B == ⋆(⋆(A))
     D == d(d(C))
   end
-  @test 4 == length(checkForContractionInGensim(single_contract))
+  @test 4 == count_contractions(single_contract)
+
+  @test 0 == count_contractions(gensim(single_contract; contract=false))
 
   sim = eval(gensim(single_contract))
   f = sim(earth, default_dec_generate)
@@ -403,7 +402,7 @@ end
 
     D == d(d(C))
   end
-  @test 4 == length(checkForContractionInGensim(single_contract))
+  @test 4 == count_contractions(contract_with_summation)
 
   sim = eval(gensim(contract_with_summation))
   f = sim(earth, default_dec_generate)
@@ -430,7 +429,7 @@ end
 
     D == d(d(C))
   end
-  @test 4 == length(checkForContractionInGensim(single_contract))
+  @test 4 == count_contractions(contract_with_op2)
 
   for prealloc in [false, true]
     let sim = eval(gensim(contract_with_op2, preallocate = prealloc))
@@ -456,7 +455,7 @@ end
     B == A * A
     D == ⋆(⋆(B))
   end
-  @test 4 == length(checkForContractionInGensim(single_contract))
+  @test 2 == count_contractions(later_contraction)
 
   sim = eval(gensim(later_contraction))
   f = sim(earth, default_dec_generate)
@@ -476,7 +475,7 @@ end
     D == ∂ₜ(A)
     D == d(A)
   end
-  @test 0 == length(checkForContractionInGensim(no_contraction))
+  @test 0 == count_contractions(no_contraction)
 
   sim = eval(gensim(no_contraction))
   f = sim(earth, default_dec_generate)
@@ -496,7 +495,7 @@ end
     D == ∂ₜ(A)
     D == d(k(A))
   end
-  @test 0 == length(checkForContractionInGensim(no_unallowed))
+  @test 0 == count_contractions(no_unallowed)
 
   sim = eval(gensim(no_unallowed))
 

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -364,30 +364,38 @@ end
 
   # Testing simple contract operations
   single_contract = @decapode begin
-    (A,C)::Form0
-    (D)::Form2
+    (A,C,E)::Form0
+    (D,F)::Form2
 
     B == ∂ₜ(A)
     D == ∂ₜ(C)
 
     B == ⋆(⋆(A))
     D == d(d(C))
+    F == d(d(E))
   end
   @test 4 == count_contractions(single_contract)
 
   @test 0 == count_contractions(gensim(single_contract; contract=false))
 
+  f = gensim(single_contract)
+  @test f.args[2].args[2].args[5].args[[2,4]] == [
+    :(var"GenSim-M_GenSim-ConMat_0" = var"GenSim-M_d₁" * var"GenSim-M_d₀"),
+    :(var"GenSim-M_GenSim-ConMat_1" = var"GenSim-M_⋆₀⁻¹" * var"GenSim-M_⋆₀")]
+
   sim = eval(gensim(single_contract))
   f = sim(earth, default_dec_generate)
   A = 2 * ones(nv(earth))
   C = ones(nv(earth))
-  u = ComponentArray(A=A, C=C)
-  du = ComponentArray(A=zeros(nv(earth)), C=zeros(ntriangles(earth)))
+  E = ones(nv(earth))
+  u = ComponentArray(A=A, C=C, E=E)
+  du = ComponentArray(A=zeros(nv(earth)), C=zeros(ntriangles(earth)), E=zeros(ntriangles(earth)))
   constants_and_parameters = ()
   f(du, u, constants_and_parameters, 0)
 
   @test du.A ≈ 2 * ones(nv(earth))
   @test du.C == zeros(ntriangles(earth))
+  @test du.E == zeros(ntriangles(earth))
 
   # Testing contraction interrupted by summation
   contract_with_summation = @decapode begin

--- a/test/simulation_core.jl
+++ b/test/simulation_core.jl
@@ -232,7 +232,7 @@ import Decapodes: compile_env, InvalidCodeTargetException
   # Test that error throws on unknown code target
   let d = @decapode begin end
     struct BadTarget <: AbstractGenerationTarget end
-    @test_throws InvalidCodeTargetException compile_env(d, [:test], Symbol[], BadTarget())
+    @test_throws InvalidCodeTargetException compile_env(d, Set{Symbol}([:test]), Symbol[], BadTarget())
   end
 
 end

--- a/test/simulation_core.jl
+++ b/test/simulation_core.jl
@@ -232,7 +232,7 @@ import Decapodes: compile_env, InvalidCodeTargetException
   # Test that error throws on unknown code target
   let d = @decapode begin end
     struct BadTarget <: AbstractGenerationTarget end
-    @test_throws InvalidCodeTargetException compile_env(d, [:test], Set{Symbol}(), BadTarget())
+    @test_throws InvalidCodeTargetException compile_env(d, [:test], Symbol[], BadTarget())
   end
 
 end


### PR DESCRIPTION
Currently, when compiling a Decapode, certain chains of matrix operations are pre-multiplied into single matrices. This cuts down on the number of matrix-vector multiplications in generated simulation code.

However the pre-multiplication of matrix operators can cause issues for certain autodiff implementations.

So, this PR adds a keyword argument to `gensim` that controls this behavior.