### PR TITLE
Adding Dynamic Buildkite Pipeline

### DIFF
--- a/.buildkite/build_docs.sh
+++ b/.buildkite/build_docs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#SBATCH --job-name=diagrammatic_equations_CI_docs    # Job name
+#SBATCH --mail-type=END,FAIL          # Mail events (NONE, BEGIN, END, FAIL, ALL)
+#SBATCH --mail-user=cuffaro.m@ufl.edu # Where to send mail	
+#SBATCH --ntasks=1                    # Run on a single CPU
+#SBATCH --mem=8gb                     # Job memory request
+#SBATCH --time=00:15:00               # Time limit hrs:min:sec
+
+pwd; hostname; date
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 1.10.0"
+    exit 1
+fi
+
+VERSION=$1
+
+module load julia/$VERSION
+
+echo "Building documentation..."
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/.buildkite/build_docs.sh
+++ b/.buildkite/build_docs.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-#SBATCH --job-name=diagrammatic_equations_CI_docs    # Job name
-#SBATCH --mail-type=END,FAIL          # Mail events (NONE, BEGIN, END, FAIL, ALL)
-#SBATCH --mail-user=cuffaro.m@ufl.edu # Where to send mail	
-#SBATCH --ntasks=1                    # Run on a single CPU
-#SBATCH --mem=8gb                     # Job memory request
-#SBATCH --time=00:15:00               # Time limit hrs:min:sec
-
 pwd; hostname; date
 
 if [ $# -ne 1 ]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,5 @@
 steps:
 
-  - label: "Testing order of operations"
-    command:
-      - "module load julia"
-      - "julia --project=docs --color=yes -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
-
-  - wait
-
   - label: ":arrow_down: Load AlgebraicJulia pipeline"
     command: |
       curl -s https://raw.githubusercontent.com/AlgebraicJulia/.github/main/buildkite/pipeline.yml | buildkite-agent pipeline upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,12 @@
 steps:
 
+  - label: "Testing order of operations"
+    command:
+      - "module load julia"
+       - "julia --project=docs --color=yes -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
+
+  - wait
+
   - label: ":arrow_down: Load AlgebraicJulia pipeline"
     command: |
       curl -s https://raw.githubusercontent.com/AlgebraicJulia/.github/main/buildkite/pipeline.yml | buildkite-agent pipeline upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,24 +1,7 @@
-env:
-  JULIA_VERSION: "1.10.2"
-  GATAS_HOME: "~/../../blue/fairbanksj/.gatas/bk/agents/$BUILDKITE_AGENT_NAME"
-
 steps:
 
-  - label: ":hammer: Build Project"
-    env:
-      JULIA_DEPOT_PATH: "$GATAS_HOME"
-    command: 
-      - "module load julia"
-      - "julia --project=docs --color=yes -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
-         
-  - wait 
-
-  - label: ":scroll: Build docs and run tests"
-    env:
-      JULIA_DEPOT_PATH: "$GATAS_HOME"
-      JULIA_PROJECT: "docs/"
-    command:
-      - "srun --cpus-per-task=16 --mem=64G --time=1:00:00 --output=.buildkite/log_%j.log --unbuffered .buildkite/jobscript.sh"
+  - label: ":arrow_down: Load AlgebraicJulia pipeline"
+    command: |
+      curl -s https://raw.githubusercontent.com/AlgebraicJulia/.github/main/buildkite/pipeline.yml | buildkite-agent pipeline upload
 
   - wait
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
   - label: "Testing order of operations"
     command:
       - "module load julia"
-       - "julia --project=docs --color=yes -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
+      - "julia --project=docs --color=yes -e 'using Pkg; Pkg.update(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
 
   - wait
 

--- a/.buildkite/run_tests.sh
+++ b/.buildkite/run_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH --job-name=diagrammatic_equations_CI_test    # Job name
+#SBATCH --mail-type=END,FAIL          # Mail events (NONE, BEGIN, END, FAIL, ALL)
+#SBATCH --mail-user=cuffaro.m@ufl.edu # Where to send mail	
+#SBATCH --ntasks=1                    # Run on a single CPU
+#SBATCH --mem=8gb                     # Job memory request
+#SBATCH --time=00:15:00               # Time limit hrs:min:sec
+
+pwd; hostname; date
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 1.10.0"
+    exit 1
+fi
+
+VERSION=$1
+
+module load julia/$VERSION
+
+echo "Running tests..."
+julia --project -e "using Pkg; Pkg.status(); Pkg.test()"

--- a/.buildkite/run_tests.sh
+++ b/.buildkite/run_tests.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-#SBATCH --job-name=diagrammatic_equations_CI_test    # Job name
-#SBATCH --mail-type=END,FAIL          # Mail events (NONE, BEGIN, END, FAIL, ALL)
-#SBATCH --mail-user=cuffaro.m@ufl.edu # Where to send mail	
-#SBATCH --ntasks=1                    # Run on a single CPU
-#SBATCH --mem=8gb                     # Job memory request
-#SBATCH --time=00:15:00               # Time limit hrs:min:sec
 
 pwd; hostname; date
 


### PR DESCRIPTION
This closes out a long-standing need to make Buildkite pipelines dynamic and GPU-enabled for Decapodes. Pipelines are imported from AlgebraicJulia `.github` repository but can be customized, like in [CombinatorialSpaces](https://github.com/AlgebraicJulia/CombinatorialSpaces.jl/blob/cm/buildkite/.buildkite/pipeline.yml)

:construction: 
[This build](https://buildkite.com/algebraicjulia/decapodes/builds/720#01943711-8711-44ef-b7e1-75e2f1c57aff) works but [this most recent rebuild](https://buildkite.com/algebraicjulia/decapodes/builds/731#01946a9c-923c-4178-936c-e871d08a4a84) does not, attributed to a "curl error code 60."