### PR TITLE
Add wrappers for 1D sharps

### DIFF
--- a/docs/src/ice_dynamics/ice_dynamics.md
+++ b/docs/src/ice_dynamics/ice_dynamics.md
@@ -210,11 +210,13 @@ Let's create a GIF to examine an animation of these dynamics:
 ``` @example DEC
 # Create a gif
 begin
-  frames = 100
-  fig, ax, ob = lines(map(x -> x[1], point(s)), soln(0).dynamics_h)
-  ylims!(ax, extrema(h₀))
-  record(fig, "ice_dynamics1D.gif", range(0.0, tₑ; length=frames); framerate = 15) do t
-    lines!(map(x -> x[1], point(s)), soln(t).dynamics_h)
+  time = Observable(0.0)
+  ys = @lift(getproperty(soln($time), :dynamics_h))
+  xcoords = map(x -> x[1], point(s))
+  fig, ax, ob = lines(xcoords, ys, colorrange=extrema(h₀);
+    axis = (; title = "1D Ice Thickness"))
+  record(fig, "ice_dynamics1D.gif", range(0, tₑ, length=30); framerate=15) do t
+    time[] = t
   end
 end
 ```

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -24,8 +24,9 @@ function default_dec_generate(sd::HasDeltaSet, my_symbol::Symbol, hodge::Discret
     :ln => (x -> log.(x))
 
     # Musical Isomorphisms
-    :♯ᵖᵖ => dec_♯_p(sd)
-    :♯ᵈᵈ => dec_♯_d(sd)
+    :♯ᵖᵈ => dec_♯_pd(sd)
+    :♯ᵖᵖ => dec_♯_pp(sd)
+    :♯ᵈᵈ => dec_♯_dd(sd)
     :♭ᵈᵖ => dec_♭(sd)
 
     # Primal-Dual Wedge Products
@@ -161,12 +162,24 @@ function dec_pair_wedge_product(::Type{Tuple{0,0}}, sd::HasDeltaSet)
   error("Replace me in compiled code with element-wise multiplication (.*)")
 end
 
-function dec_♯_p(sd::HasDeltaSet2D)
+function dec_♯_pd(sd::HasDeltaSet1D)
+  x -> ♯(sd, x, PDSharp())
+end
+
+function dec_♯_pp(sd::HasDeltaSet1D)
+  x -> ♯(sd, x, PPSharp())
+end
+
+function dec_♯_pd(sd::HasDeltaSet2D)
+  error("Primal-dual sharp is not yet implemented for 2D complexes.")
+end
+
+function dec_♯_pp(sd::HasDeltaSet2D)
   ♯_m = ♯_mat(sd, AltPPSharp())
   x -> ♯_m * x
 end
 
-function dec_♯_d(sd::HasDeltaSet2D)
+function dec_♯_dd(sd::HasDeltaSet2D)
   ♯_m = ♯_mat(sd, LLSDDSharp())
   x -> ♯_m * x
 end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -599,11 +599,10 @@ const MATRIX_OPTIMIZABLE_DEC_OPERATORS = Set([:⋆₀, :⋆₁, :⋆₂, :⋆₀
 const NONMATRIX_OPTIMIZABLE_DEC_OPERATORS = Set([:⋆₁⁻¹, :∧₀₁, :∧₁₀, :∧₁₁, :∧₀₂, :∧₂₀])
 
 
-const NON_OPTIMIZABLE_CPU_OPERATORS = Set([:♯ᵖᵖ, :♯ᵈᵈ, :♭ᵈᵖ,
+const NON_OPTIMIZABLE_CPU_OPERATORS = Set([:♯ᵖᵈ, :♯ᵖᵖ, :♯ᵈᵈ, :♭ᵈᵖ,
                                            :∧ᵖᵈ₁₁, :∧ᵖᵈ₀₁, :∧ᵈᵖ₁₁, :∧ᵈᵖ₁₀, :∧ᵈᵈ₁₁, :∧ᵈᵈ₁₀, :∧ᵈᵈ₀₁,
                                            :ι₁₁, :ι₁₂, :ℒ₁, :Δᵈ₀ , :Δᵈ₁, :Δ₀⁻¹, :neg])
 const NON_OPTIMIZABLE_CUDA_OPERATORS = Set{Symbol}()
-
 
 const DEC_GEN_OPTIMIZABLE_OPERATORS = MATRIX_OPTIMIZABLE_DEC_OPERATORS ∪ NONMATRIX_OPTIMIZABLE_DEC_OPERATORS
 


### PR DESCRIPTION
[CombinatorialSpaces PR 136](https://github.com/AlgebraicJulia/CombinatorialSpaces.jl/pull/136) upstreamed and tested a 1D primal-primal sharp operation, as well as a new 1D primal-dual sharp operation.

This PR adds internal bindings for the Decapodes code emission for these operators. The superscripting scheme for these operators mirrors those for 2D. This is tested in the documentation via the Ice Dynamics page.