### PR TITLE
Test ensemble problems on CPU and GPU

### DIFF
--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -8,7 +8,7 @@ using Test
 
 using MLStyle
 using CombinatorialSpaces
-using GeometryBasics: Point3
+using GeometryBasics: Point2, Point3
 using LinearAlgebra
 using Distributions
 using ComponentArrays
@@ -16,6 +16,7 @@ using OrdinaryDiffEq
 using DiagrammaticEquations
 using DiagrammaticEquations.Deca
 using GeometryBasics
+Point2D = Point2{Float64}
 
 function test_hodge(k, sd::HasDeltaSet, hodge)
   hodge = ⋆(k,sd,hodge=hodge)
@@ -811,5 +812,47 @@ nallocs = @allocations f(du, u₀, p, (0,1.0))
   sizeof(u₀.C) +
   sizeof(p.D) +
   sizeof(Decapodes.FixedSizeDiffCache(Vector{Float64}(undef , nparts(sd, :V))))
+end
+
+@testset "Ensemble Simulations" begin
+# Define Model
+Heat = @decapode begin
+  C::Form0
+  D::Constant
+  ∂ₜ(C) == D*Δ(C)
+end
+# Define Domain
+function circle(n, c)
+  s = EmbeddedDeltaSet1D{Bool, Point2D}()
+  map(range(0, 2pi - (pi/(2^(n-1))); step=pi/(2^(n-1)))) do t
+    add_vertex!(s, point=Point2D(cos(t),sin(t))*(c/2pi))
+  end
+  add_edges!(s, 1:(nv(s)-1), 2:nv(s))
+  add_edge!(s, nv(s), 1)
+  sd = EmbeddedDeltaDualComplex1D{Bool, Float64, Point2D}(s)
+  subdivide_duals!(sd, Circumcenter())
+  s,sd
+end
+s,sd = circle(7, 500)
+# Create initial data.
+Csin = map(p -> sin(p[1]), point(s))
+Ccos = map(p -> cos(p[1]), point(s))
+C = stack([Csin, Ccos])
+u₀ = ComponentArray(C=Csin,)
+constants_and_parameters = (D = 0.001,)
+# Run
+function generate(sd, my_symbol; hodge=GeometricHodge()) end
+sim = eval(gensim(Heat,dimension=1))
+fₘ = sim(sd, nothing)
+tₑ = 1.15
+ode_prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+ens_prob = EnsembleProblem(ode_prob,
+                      prob_func = (prob, i, repeat) ->
+                        remake(prob, u0=ComponentArray(C=C[:,i])))
+soln = solve(ens_prob, Tsit5(); trajectories=2)
+@test all(soln[1].u[1] .== Csin)
+@test all(soln[1].u[1] .!= Ccos)
+@test all(soln[2].u[1] .!= Csin)
+@test all(soln[2].u[1] .== Ccos)
 end
 


### PR DESCRIPTION
Previously, we used the Decapodes documentation for particular examples of physics. Now, we have both examples in the "zoo", as well as demonstrations of particular tasks you might want to do with a Decapodes simulation that might not tie into a larger story.

I am reviving this old branch since this demonstration of ensemble simulations may be suitable as a docs page, and may find use in yet-unknown contexts.