### PR TITLE
3D Diffusion and Advection

### DIFF
--- a/examples/diff_adv/3d_adv.jl
+++ b/examples/diff_adv/3d_adv.jl
@@ -1,0 +1,66 @@
+using Decapodes
+using DiagrammaticEquations
+using CombinatorialSpaces
+using GeometryBasics
+using MLStyle
+using ComponentArrays
+using OrdinaryDiffEq
+using GLMakie
+using Distributions
+
+lx = 100
+ly = lz = 50
+
+s = parallelepiped(lx = lx, ly = ly, lz = lz; tetcmd = "vpVq2a2.5")
+sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
+subdivide_duals!(sd, Circumcenter())
+
+# GLMakie.wireframe(s)
+
+wdg_01 = dec_wedge_product(Tuple{0,1}, sd)
+star₁_mat = hodge_star(1,sd,DiagonalHodge())
+dual_d₂_mat = dual_derivative(2,sd)
+inv_star₃_mat = inv_hodge_star(0,sd,DiagonalHodge())
+
+codif = inv_star₃_mat * dual_d₂_mat * star₁_mat
+
+T_dist = MvNormal([30, ly/2, lz/2], [10,10,10])
+T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[:point]] / 1000
+T₀ = T
+GLMakie.mesh(s; color = T, transparency=true, shading=NoShading)
+
+c = 1
+
+#TODO: Work on this, same as 2D basically
+u = eval_constant_primal_form(sd, Point3d(1,0,0))
+
+u₀ = ComponentArray(T=T, u=u)
+
+function adv(du, u, p, t)
+    du.T .-= p.c * inv_star₃_mat * dual_d₂_mat * star₁_mat * wdg_01(u.T, u.u)
+end
+
+tₑ = 10
+prob = ODEProblem(adv, u₀, (0, tₑ), (c=c,))
+soln = solve(prob, Tsit5(), saveat = 0.1)
+
+GLMakie.mesh(s; color = soln.u[end].T, transparency=true, shading=NoShading, colorrange = extrema(T₀))
+
+function save_dynamics(save_file_name, video_length = 30)
+  time = Observable(0.0)
+
+  T = @lift(soln($time).T)
+
+  f = Figure()
+
+  ls_T = GLMakie.LScene(f[1, 1])
+  msh_T = GLMakie.mesh!(ls_T, s; color=T, colorrange = extrema(T₀), transparency=true, shading=NoShading)
+  Colorbar(f[1,2], msh_T)
+
+  timestamps = range(0, soln.t[end], length=video_length)
+  record(f, save_file_name, timestamps; framerate = 15) do t
+    time[] = t
+  end
+end
+
+save_dynamics("3d_adv.mp4", 30)

--- a/examples/diff_adv/3d_adv.jl
+++ b/examples/diff_adv/3d_adv.jl
@@ -5,29 +5,30 @@ using ComponentArrays
 using OrdinaryDiffEq
 using GLMakie
 using Distributions
+using SparseArrays
 
 lx = 100
 ly = lz = 30
 
 s = parallelepiped(lx = lx, ly = ly, lz = lz; tetcmd = "vpVq2a5")
 sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
-subdivide_duals!(sd, Circumcenter())
+subdivide_duals!(sd, Barycenter())
 
 # GLMakie.wireframe(s)
 
-Adv = @decapode begin
-    T::Form0
-    U::Form1
-    c::Constant
-    ∂ₜ(T) == -c*(δ(T ∧ U))
-end
-
 # Adv = @decapode begin
-#     T::DualForm0
+#     T::Form0
 #     U::Form1
 #     c::Constant
-#     ∂ₜ(T) == -c*L(U, T)
+#     ∂ₜ(T) == -c*(δ(T ∧ U))
 # end
+
+Adv = @decapode begin
+    T::DualForm0
+    U::Form1
+    c::Constant
+    ∂ₜ(T) == -c*⋆(∧(⋆(d(T)), U))
+end
 
 infer_types!(Adv, dim=3)
 resolve_overloads!(Adv, dim=3)
@@ -39,11 +40,32 @@ sim = evalsim(Adv, dimension=3)
 f = sim(sd, nothing, DiagonalHodge())
 
 T_dist = MvNormal([lx/2, ly/2, lz/2], [5,5,5])
-T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[:point]]
-# T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[tetrahedron_center(sd), :dual_point]]
+# T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[:point]]
+T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[tetrahedron_center(sd), :dual_point]]
 
 T₀ = T
-GLMakie.mesh(s; color = T, transparency=true, shading=NoShading)
+
+function p3_d3_interpolation(sd::HasDeltaSet3D)
+  mat = spzeros(nv(sd), ntetrahedra(sd))
+  for tet_id in tetrahedra(sd)
+    tet_vol = sd[tet_id, :vol]
+    for dual_tet_id in (1:24) .+ 24 * (tet_id - 1)
+      dual_tet_vol = sd[dual_tet_id, :dual_vol]
+
+      weight = (dual_tet_vol / tet_vol)
+
+      v = sd[sd[sd[dual_tet_id, :D_∂t1], :D_∂e2], :D_∂v1]
+
+      mat[v, tet_id] += weight
+    end
+  end
+
+  mat
+end
+
+interp = d0_p0_interpolation(sd)
+
+GLMakie.mesh(s; color = interp * T, transparency=true, shading=NoShading)
 
 U = eval_constant_primal_form(sd, Point3d(1,0,0))
 
@@ -55,7 +77,7 @@ tₑ = 20
 prob = ODEProblem(f, u₀, (0, tₑ), (c=c,))
 soln = solve(prob, Tsit5(), saveat = 0.1)
 
-GLMakie.mesh(s; color = soln.u[end].T, transparency=true, shading=NoShading, colorrange = extrema(T₀))
+GLMakie.mesh(s; color = interp * soln.u[end].T, transparency=true, shading=NoShading, colorrange = extrema(interp * T₀))
 
 function save_dynamics(save_file_name, video_length = 30)
   time = Observable(0.0)

--- a/examples/diff_adv/3d_adv.jl
+++ b/examples/diff_adv/3d_adv.jl
@@ -1,8 +1,6 @@
 using Decapodes
 using DiagrammaticEquations
 using CombinatorialSpaces
-using GeometryBasics
-using MLStyle
 using ComponentArrays
 using OrdinaryDiffEq
 using GLMakie
@@ -21,11 +19,20 @@ Adv = @decapode begin
     T::Form0
     U::Form1
     c::Constant
-    ∂ₜ(T) == -c*(⋆(d(⋆(T ∧ U))))
+    ∂ₜ(T) == -c*(δ(T ∧ U))
 end
+
+# Adv = @decapode begin
+#     T::DualForm0
+#     U::Form1
+#     c::Constant
+#     ∂ₜ(T) == -c*L(U, T)
+# end
 
 infer_types!(Adv, dim=3)
 resolve_overloads!(Adv, dim=3)
+
+gensim(Adv, dimension=3)
 
 sim = evalsim(Adv, dimension=3)
 
@@ -33,6 +40,8 @@ f = sim(sd, nothing, DiagonalHodge())
 
 T_dist = MvNormal([lx/2, ly/2, lz/2], [5,5,5])
 T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[:point]]
+# T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[tetrahedron_center(sd), :dual_point]]
+
 T₀ = T
 GLMakie.mesh(s; color = T, transparency=true, shading=NoShading)
 

--- a/examples/diff_adv/3d_heat.jl
+++ b/examples/diff_adv/3d_heat.jl
@@ -60,4 +60,4 @@ function save_dynamics(save_file_name, video_length = 30)
   end
 end
 
-save_dynamics("3d_heat.mp4", 120)
+save_dynamics("3d_heat.mp4", 60)

--- a/examples/diff_adv/3d_heat.jl
+++ b/examples/diff_adv/3d_heat.jl
@@ -10,7 +10,7 @@ using Distributions
 
 lx = ly = lz = 10
 
-s = parallelepiped(lx = lx, ly = ly, lz = lz; tetcmd = "vpq1.5a0.05")
+s = parallelepiped(lx = lx, ly = ly, lz = lz; tetcmd = "vpq1.5a0.25")
 sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
 subdivide_duals!(sd, Circumcenter())
 GLMakie.wireframe(s)
@@ -18,7 +18,7 @@ GLMakie.wireframe(s)
 Heat = @decapode begin
     T::Form0
     D::Constant
-    ∂ₜ(T) == D * ⋆(d(⋆(d(T))))
+    ∂ₜ(T) == D * Δ(T)
 end
 
 infer_types!(Heat, dim=3)

--- a/examples/diff_adv/3d_heat.jl
+++ b/examples/diff_adv/3d_heat.jl
@@ -13,15 +13,20 @@ lx = ly = lz = 10
 s = parallelepiped(lx = lx, ly = ly, lz = lz; tetcmd = "vpq1.5a0.05")
 sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
 subdivide_duals!(sd, Circumcenter())
-
 GLMakie.wireframe(s)
 
-d₀_mat = CombinatorialSpaces.d(0,sd)
-star₁_mat = hodge_star(1,sd,DiagonalHodge())
-dual_d₂_mat = dual_derivative(2,sd)
-inv_star₃_mat = inv_hodge_star(0,sd,DiagonalHodge())
+Heat = @decapode begin
+    T::Form0
+    D::Constant
+    ∂ₜ(T) == D * ⋆(d(⋆(d(T))))
+end
 
-lap_mat = inv_star₃_mat * dual_d₂_mat * star₁_mat * d₀_mat
+infer_types!(Heat, dim=3)
+resolve_overloads!(Heat, dim=3)
+
+sim = evalsim(Heat, dimension=3)
+
+f = sim(sd, nothing, DiagonalHodge())
 
 T_dist = MvNormal([lx/2, ly/2, lx/2], [1, 1, 1])
 T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[:point]]
@@ -32,12 +37,8 @@ D = 0.1
 
 u₀ = ComponentArray(T=T)
 
-function diff(du, u, p, t)
-    du .= p.D * lap_mat*u
-end
-
 tₑ = 100
-prob = ODEProblem(diff, u₀, (0, tₑ), (D = D,))
+prob = ODEProblem(f, u₀, (0, tₑ), (D = D,))
 soln = solve(prob, Tsit5(), saveat = 1)
 
 GLMakie.mesh(s; color = soln.u[end].T, transparency=true, shading=NoShading)
@@ -60,29 +61,3 @@ function save_dynamics(save_file_name, video_length = 30)
 end
 
 save_dynamics("3d_heat.mp4", 120)
-
-# TODO: Allow support for 3D sims through Decapodes
-# Heat = @decapode begin
-#     U::Form0
-#     D::Constant
-#     ∂ₜ(U) == D * Δ(U)
-# end
-
-# simulate = evalsim(Heat)
-  
-# fₘ = simulate(sd, nothing)
-
-# U = map(sd[:point]) do (x,_)
-#         return x
-#     end
-
-# u₀ = ComponentArray(U=U)
-
-# constants_and_parameters = ()
-
-# tₑ = 11.5
-
-# @info("Solving")
-# prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
-# soln = solve(prob, Tsit5())
-# @info("Done")

--- a/examples/diff_adv/3d_heat.jl
+++ b/examples/diff_adv/3d_heat.jl
@@ -1,0 +1,88 @@
+using Decapodes
+using DiagrammaticEquations
+using CombinatorialSpaces
+using GeometryBasics
+using MLStyle
+using ComponentArrays
+using OrdinaryDiffEq
+using GLMakie
+using Distributions
+
+lx = ly = lz = 10
+
+s = parallelepiped(lx = lx, ly = ly, lz = lz; tetcmd = "vpq1.5a0.05")
+sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
+subdivide_duals!(sd, Circumcenter())
+
+GLMakie.wireframe(s)
+
+d₀_mat = CombinatorialSpaces.d(0,sd)
+star₁_mat = hodge_star(1,sd,DiagonalHodge())
+dual_d₂_mat = dual_derivative(2,sd)
+inv_star₃_mat = inv_hodge_star(0,sd,DiagonalHodge())
+
+lap_mat = inv_star₃_mat * dual_d₂_mat * star₁_mat * d₀_mat
+
+T_dist = MvNormal([lx/2, ly/2, lx/2], [1, 1, 1])
+T = [pdf(T_dist, [p[1], p[2], p[3]]) for p in sd[:point]]
+
+GLMakie.mesh(s; color = T, transparency=true, shading=NoShading)
+
+D = 0.1
+
+u₀ = ComponentArray(T=T)
+
+function diff(du, u, p, t)
+    du .= p.D * lap_mat*u
+end
+
+tₑ = 100
+prob = ODEProblem(diff, u₀, (0, tₑ), (D = D,))
+soln = solve(prob, Tsit5(), saveat = 1)
+
+GLMakie.mesh(s; color = soln.u[end].T, transparency=true, shading=NoShading)
+
+function save_dynamics(save_file_name, video_length = 30)
+  time = Observable(0.0)
+
+  T = @lift(soln($time).T)
+
+  f = Figure()
+
+  ls_T = GLMakie.LScene(f[1, 1])
+  msh_T = GLMakie.mesh!(ls_T, s; color=T, colormap=:jet, transparency=true, shading=NoShading)
+  Colorbar(f[1,2], msh_T)
+
+  timestamps = range(0, soln.t[end], length=video_length)
+  record(f, save_file_name, timestamps; framerate = 15) do t
+    time[] = t
+  end
+end
+
+save_dynamics("3d_heat.mp4", 120)
+
+# TODO: Allow support for 3D sims through Decapodes
+# Heat = @decapode begin
+#     U::Form0
+#     D::Constant
+#     ∂ₜ(U) == D * Δ(U)
+# end
+
+# simulate = evalsim(Heat)
+  
+# fₘ = simulate(sd, nothing)
+
+# U = map(sd[:point]) do (x,_)
+#         return x
+#     end
+
+# u₀ = ComponentArray(U=U)
+
+# constants_and_parameters = ()
+
+# tₑ = 11.5
+
+# @info("Solving")
+# prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+# soln = solve(prob, Tsit5())
+# @info("Done")

--- a/examples/diff_adv/adv.jl
+++ b/examples/diff_adv/adv.jl
@@ -1,0 +1,98 @@
+using Decapodes
+using DiagrammaticEquations
+using CombinatorialSpaces
+using GeometryBasics
+using MLStyle
+using ComponentArrays
+using OrdinaryDiffEq
+using CairoMakie
+using Distributions
+
+INITCOND = "test"
+RESOLUTION = 0.5
+
+lx = 100
+ly = 30
+
+s = triangulated_grid(lx, ly, RESOLUTION, RESOLUTION, Point3D)
+sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s)
+subdivide_duals!(sd, Circumcenter())
+
+Adv = @decapode begin
+    T::Form0
+    u::Form1
+    ∂ₜ(T) == -(⋆(d(⋆(T ∧ u))))
+end
+infer_types!(Adv)
+resolve_overloads!(Adv)
+
+simulate = evalsim(Adv)
+fₘ = simulate(sd, nothing)
+
+if INITCOND == "square"
+    T = map(sd[:point]) do p
+        if 40 <= p[1] <= 60 && 40 <= p[2] <= 60
+            return 1
+        else
+            return 0
+        end
+    end
+else
+    T_dist = MvNormal([lx/2, ly/2], [5, 5])
+    T = [pdf(T_dist, [p[1], p[2]]) for p in sd[:point]]
+end
+T₀ = T
+
+fig = Figure();
+ax = CairoMakie.Axis(fig[1,1])
+msh = CairoMakie.mesh!(ax, s, color=T, colormap=:jet, colorrange=extrema(T))
+Colorbar(fig[1,2], msh)
+fig
+
+u = eval_constant_primal_form(sd, Point3d(1, 0, 0))
+
+u₀ = ComponentArray(T=T,u=u)
+
+constants_and_parameters = ()
+
+tₑ = 20
+
+@info("Solving")
+prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
+soln = solve(prob, Tsit5())
+@info("Done")
+
+FILENAME = "$(INITCOND)_mesh_$(RESOLUTION)_res"
+
+function save_dynamics(save_file_name, video_length = 30)
+  time = Observable(0.0)
+
+  T = @lift(soln($time).T)
+  f = Figure()
+  ax_T = CairoMakie.Axis(f[1,1], title = @lift("Temperature at Time $(round($time, digits=3))"))
+  msh_T = mesh!(ax_T, s; color=T, colormap=:jet, colorrange = extrema(T₀))
+  Colorbar(f[1,2], msh_T)
+
+  timestamps = range(0, soln.t[end], length=video_length)
+  record(f, save_file_name, timestamps; framerate = 15) do t
+    time[] = t
+  end
+end
+
+save_dynamics("$(FILENAME).mp4")
+
+# fig = Figure();
+# ax = CairoMakie.Axis(fig[1,1])
+# msh = CairoMakie.mesh!(ax, s, color=soln.u[end].T, colormap=:jet, colorrange=extrema(T))
+# Colorbar(fig[1,2], msh)
+# fig
+
+energy_conv = map(t -> sum(soln(t).T), soln.t) .- sum(T)
+
+fig = Figure(size=(2000, 1000));
+ax = CairoMakie.Axis(fig[1,1])
+msh = CairoMakie.mesh!(ax, s, color=soln.u[end].T, colormap=:jet, colorrange=extrema(T))
+Colorbar(fig[1,2], msh)
+ax2 = CairoMakie.Axis(fig[1,3]; title = "Energy conservation with $(INITCOND) mesh")
+CairoMakie.plot!(ax2, soln.t, energy_conv)
+save("$(FILENAME).png", fig)

--- a/examples/diff_adv/test_adv.jl
+++ b/examples/diff_adv/test_adv.jl
@@ -1,0 +1,41 @@
+using CombinatorialSpaces
+
+s = EmbeddedDeltaSet3D{Bool,Point3d}()
+add_vertices!(s, 4, point=[Point3d(0,0,0), Point3d(1,0,0),
+  Point3d(0,1,0), Point3d(0,0,1)])
+glue_tetrahedron!(s, 1, 2, 3, 4)
+orient!(s)
+sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
+subdivide_duals!(sd, Circumcenter())
+
+wdg_01 = dec_wedge_product(Tuple{0,1}, sd)
+star₁_mat = hodge_star(1,sd,DiagonalHodge())
+dual_d₂_mat = dual_derivative(2,sd)
+inv_star₃_mat = inv_hodge_star(0,sd,DiagonalHodge())
+
+codif = inv_star₃_mat * dual_d₂_mat * star₁_mat
+
+T = Float64[1,0,0,0]
+u = eval_constant_primal_form(sd, Point3d(1,0,0))
+
+@show -(codif * wdg_01(T, u))
+
+s = EmbeddedDeltaSet2D{Bool,Point3d}()
+add_vertices!(s, 3, point=[Point3d(0,0,0), Point3d(1,0,0),
+  Point3d(0,1,0)])
+glue_triangle!(s, 1, 2, 3)
+orient!(s)
+sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s)
+subdivide_duals!(sd, Circumcenter())
+
+wdg_01 = dec_wedge_product(Tuple{0,1}, sd)
+star₁_mat = hodge_star(1,sd,DiagonalHodge())
+dual_d₁_mat = dual_derivative(1,sd)
+inv_star₃_mat = inv_hodge_star(0,sd,DiagonalHodge())
+
+codif = inv_star₃_mat * dual_d₁_mat * star₁_mat
+
+T = Float64[1,0,0]
+u = eval_constant_primal_form(sd, Point3d(1,0,0))
+
+@show -(codif * wdg_01(T, u))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -83,25 +83,25 @@ function default_dec_matrix_generate(sd::HasDeltaSet, my_symbol::Symbol, hodge::
 
     # Regular Hodge Stars
     :⋆₀ => dec_hodge_star(0, sd, hodge=hodge) |> matmul
-    :⋆₁ => hodge_star(1, sd, hodge=hodge) |> matmul #TODO: Revert to dec_, need for 3D
+    :⋆₁ => dec_hodge_star(1, sd, hodge=hodge) |> matmul
     :⋆₂ => dec_hodge_star(2, sd, hodge=hodge) |> matmul
-    :⋆₃ => hodge_star(3, sd, hodge=hodge) |> matmul # TODO: Needs dec_ and geometric
+    :⋆₃ => dec_hodge_star(3, sd, hodge=hodge) |> matmul
 
     # Inverse Hodge Stars
-    :⋆₀⁻¹ => inv_hodge_star(0, sd, hodge) |> matmul #TODO: Revert to dec_, need for 3D
+    :⋆₀⁻¹ => dec_inv_hodge_star(0, sd, hodge) |> matmul
     :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge) # Special since Geo is a solver
     :⋆₂⁻¹ => dec_inv_hodge_star(2, sd, hodge) |> matmul # TODO: Needs pair for 3D Geo
-    :⋆₃⁻¹ => inv_hodge_star(3, sd, hodge) |> matmul # TODO: Needs dec_ and geometric
+    :⋆₃⁻¹ => dec_inv_hodge_star(3, sd, hodge) |> matmul
 
     # Differentials
     :d₀ => dec_differential(0, sd) |> matmul
     :d₁ => dec_differential(1, sd) |> matmul
-    :d₂ => CombinatorialSpaces.d(2, sd) |> matmul # TODO: Needs dec_
+    :d₂ => dec_differential(2, sd) |> matmul
 
     # Dual Differentials
     :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
     :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
-    :dual_d₂ || :d̃₂ => dual_derivative(2,sd) |> matmul # TODO: Needs dec_
+    :dual_d₂ || :d̃₂ => dec_dual_derivative(2,sd) |> matmul
 
     # Wedge Products
     :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)
@@ -112,7 +112,7 @@ function default_dec_matrix_generate(sd::HasDeltaSet, my_symbol::Symbol, hodge::
 
     #TODO: Need 2-1 and 1-2 wedges
 
-    :♭♯ => ♭♯_mat(sd) |> matmul
+    :♭♯ => ♭♯_mat(sd) |> matmul # TODO: Needs 3D version 
 
     # Averaging Operator
     :avg₀₁ => avg₀₁_mat(sd) |> matmul

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -83,21 +83,25 @@ function default_dec_matrix_generate(sd::HasDeltaSet, my_symbol::Symbol, hodge::
 
     # Regular Hodge Stars
     :⋆₀ => dec_hodge_star(0, sd, hodge=hodge) |> matmul
-    :⋆₁ => dec_hodge_star(1, sd, hodge=hodge) |> matmul
+    :⋆₁ => hodge_star(1, sd, hodge=hodge) |> matmul #TODO: Revert to dec_, need for 3D
     :⋆₂ => dec_hodge_star(2, sd, hodge=hodge) |> matmul
+    :⋆₃ => hodge_star(3, sd, hodge=hodge) |> matmul # TODO: Needs dec_ and geometric
 
     # Inverse Hodge Stars
-    :⋆₀⁻¹ => dec_inv_hodge_star(0, sd, hodge) |> matmul
+    :⋆₀⁻¹ => inv_hodge_star(0, sd, hodge) |> matmul #TODO: Revert to dec_, need for 3D
     :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge) # Special since Geo is a solver
-    :⋆₂⁻¹ => dec_inv_hodge_star(1, sd, hodge) |> matmul
+    :⋆₂⁻¹ => dec_inv_hodge_star(2, sd, hodge) |> matmul # TODO: Needs pair for 3D Geo
+    :⋆₃⁻¹ => inv_hodge_star(3, sd, hodge) |> matmul # TODO: Needs dec_ and geometric
 
     # Differentials
-    :d₀ => dec_differential(0, sd) |> matmul
+    :d₀ => CombinatorialSpaces.d(0, sd) |> matmul #TODO: Revert to dec_, need for 3D
     :d₁ => dec_differential(1, sd) |> matmul
+    :d₂ => CombinatorialSpaces.d(2, sd) |> matmul # TODO: Needs dec_
 
     # Dual Differentials
     :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
     :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
+    :dual_d₂ || :d̃₂ => dual_derivative(2,sd) |> matmul # TODO: Needs dec_
 
     # Wedge Products
     :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)
@@ -105,6 +109,8 @@ function default_dec_matrix_generate(sd::HasDeltaSet, my_symbol::Symbol, hodge::
     :∧₀₂ => dec_pair_wedge_product(Tuple{0,2}, sd)
     :∧₂₀ => dec_pair_wedge_product(Tuple{2,0}, sd)
     :∧₁₁ => dec_pair_wedge_product(Tuple{1,1}, sd)
+
+    #TODO: Need 2-1 and 1-2 wedges
 
     :♭♯ => ♭♯_mat(sd) |> matmul
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -323,7 +323,7 @@ function open_operators!(d::SummationDecapode; dimension::Int=2)
         add_Lie_3D!(Val{2}, d, op2_proj1, op2_proj2, op2_res)
         true
       end
-      (:L₂, 3) => begin
+      (:L₃, 3) => begin
         add_Lie_3D!(Val{3}, d, op2_proj1, op2_proj2, op2_res)
         true
       end
@@ -372,11 +372,11 @@ function add_Inter_Prod_2D!(::Type{Val{2}}, d::SummationDecapode, proj1_Inter::I
   add_Inter_Prod!(d, proj1_Inter, proj2_Inter, res_Inter)
 end
 
-function add_Inter_Prod_3D!!(::Type{Val{1}}, d::SummationDecapode, proj1_Inter::Int, proj2_Inter::Int, res_Inter::Int)
+function add_Inter_Prod_3D!(::Type{Val{1}}, d::SummationDecapode, proj1_Inter::Int, proj2_Inter::Int, res_Inter::Int)
   add_Inter_Prod!(d, proj1_Inter, proj2_Inter, res_Inter)
 end
 
-function add_Inter_Prod_3D!!(::Type{Val{2}}, d::SummationDecapode, proj1_Inter::Int, proj2_Inter::Int, res_Inter::Int)
+function add_Inter_Prod_3D!(::Type{Val{2}}, d::SummationDecapode, proj1_Inter::Int, proj2_Inter::Int, res_Inter::Int)
   ## Takes generic interior product
   pos_inter_prod = add_part!(d, :Var, type=:infer, name=nothing)
   add_Inter_Prod!(d, proj1_Inter, proj2_Inter, pos_inter_prod)
@@ -385,7 +385,7 @@ function add_Inter_Prod_3D!!(::Type{Val{2}}, d::SummationDecapode, proj1_Inter::
   add_part!(d, :Op1, src=pos_inter_prod, tgt=res_Inter, op1=:neg)
 end
 
-function add_Inter_Prod_3D!!(::Type{Val{3}}, d::SummationDecapode, proj1_Inter::Int, proj2_Inter::Int, res_Inter::Int)
+function add_Inter_Prod_3D!(::Type{Val{3}}, d::SummationDecapode, proj1_Inter::Int, proj2_Inter::Int, res_Inter::Int)
   add_Inter_Prod!(d, proj1_Inter, proj2_Inter, res_Inter)
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -94,7 +94,7 @@ function default_dec_matrix_generate(sd::HasDeltaSet, my_symbol::Symbol, hodge::
     :⋆₃⁻¹ => inv_hodge_star(3, sd, hodge) |> matmul # TODO: Needs dec_ and geometric
 
     # Differentials
-    :d₀ => CombinatorialSpaces.d(0, sd) |> matmul #TODO: Revert to dec_, need for 3D
+    :d₀ => dec_differential(0, sd) |> matmul
     :d₁ => dec_differential(1, sd) |> matmul
     :d₂ => CombinatorialSpaces.d(2, sd) |> matmul # TODO: Needs dec_
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -596,7 +596,7 @@ const MATRIX_OPTIMIZABLE_DEC_OPERATORS = Set([:⋆₀, :⋆₁, :⋆₂, :⋆₃
                                               :d₀, :d₁, :d₂, :dual_d₀, :d̃₀, :dual_d₁, :d̃₁, :dual_d₂, :d̃₂,
                                               :avg₀₁, :♭♯])
 
-const NONMATRIX_OPTIMIZABLE_DEC_OPERATORS = Set([:⋆₁⁻¹, :∧₀₁, :∧₁₀, :∧₁₁, :∧₀₂, :∧₂₀])
+const NONMATRIX_OPTIMIZABLE_DEC_OPERATORS = Set([:⋆₁⁻¹, :∧₀₁, :∧₁₀, :∧₁₁, :∧₀₂, :∧₂₀, :∧₀₃, :∧₃₀, :∧₁₂, :∧₂₁])
 
 
 const NON_OPTIMIZABLE_CPU_OPERATORS = Set([:♯ᵖᵈ, :♯ᵖᵖ, :♯ᵈᵈ, :♭ᵈᵖ,

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -537,3 +537,96 @@ end
   @test laplace_de_rham_2 == test_laplace_de_rham_2
 end
 
+@testset "Opening 3D Operators" begin
+  lie_derivative_0 = @decapode begin
+    A::DualForm0
+    B::Form1
+    C::DualForm0
+
+    C == L₀(B, A)
+  end
+  Decapodes.open_operators!(lie_derivative_0, dimension = 3)
+  infer_types!(lie_derivative_0, dim = 3)
+  resolve_overloads!(lie_derivative_0, dim = 3)
+
+  lie_derivative_1 = @decapode begin
+    A::DualForm1
+    B::Form1
+    C::DualForm1
+
+    C == L₁(B, A)
+  end
+  Decapodes.open_operators!(lie_derivative_1, dimension = 3)
+  infer_types!(lie_derivative_1, dim = 3)
+  resolve_overloads!(lie_derivative_1, dim = 3)
+
+  lie_derivative_2 = @decapode begin
+    A::DualForm2
+    B::Form1
+    C::DualForm2
+
+    C == L₂(B, A)
+  end
+  Decapodes.open_operators!(lie_derivative_2, dimension = 3)
+  infer_types!(lie_derivative_2, dim = 3)
+  resolve_overloads!(lie_derivative_2, dim = 3)
+
+  lie_derivative_3 = @decapode begin
+    A::DualForm3
+    B::Form1
+    C::DualForm3
+
+    C == L₃(B, A)
+  end
+  Decapodes.open_operators!(lie_derivative_3, dimension = 3)
+  infer_types!(lie_derivative_3, dim = 3)
+  resolve_overloads!(lie_derivative_3, dim = 3)
+
+  codiff_3 = @decapode begin
+    A::Form3
+    B::Form2
+
+    B == δ₃(A)
+  end
+  Decapodes.open_operators!(codiff_3, dimension = 3)
+  infer_types!(codiff_3, dim = 3)
+  resolve_overloads!(codiff_3, dim = 3)
+
+  laplace_de_rham_0 = @decapode begin
+    (A, B)::Form0
+
+    B == Δ₀(A)
+  end
+  Decapodes.open_operators!(laplace_de_rham_0, dimension = 3)
+  infer_types!(laplace_de_rham_0, dim = 3)
+  resolve_overloads!(laplace_de_rham_0, dim = 3)
+
+  laplace_de_rham_1 = @decapode begin
+    (A, B)::Form1
+
+    B == Δ₁(A)
+  end
+  Decapodes.open_operators!(laplace_de_rham_1, dimension = 3)
+  infer_types!(laplace_de_rham_1, dim = 3)
+  resolve_overloads!(laplace_de_rham_1, dim = 3)
+
+  laplace_de_rham_2 = @decapode begin
+    (A, B)::Form2
+
+    B == Δ₂(A)
+  end
+  Decapodes.open_operators!(laplace_de_rham_2, dimension = 3)
+  infer_types!(laplace_de_rham_2, dim = 3)
+  resolve_overloads!(laplace_de_rham_2, dim = 3)
+
+  laplace_de_rham_3 = @decapode begin
+    (A, B)::Form3
+
+    B == Δ₃(A)
+  end
+  Decapodes.open_operators!(laplace_de_rham_3, dimension = 3)
+  infer_types!(laplace_de_rham_3, dim = 3)
+  resolve_overloads!(laplace_de_rham_3, dim = 3)
+
+
+end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -549,6 +549,26 @@ end
   infer_types!(lie_derivative_0, dim = 3)
   resolve_overloads!(lie_derivative_0, dim = 3)
 
+  @test lie_derivative_0 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 6
+    name = [:A, :B, :C, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3]
+    type = [:DualForm0, :Form1, :DualForm0, :DualForm1, :Form2, :Form3]
+    Op1 = 3
+    src = [1, 4, 6]
+    tgt = [4, 5, 3]
+    op1 = [:dual_d₀, :⋆₂⁻¹, :⋆₃]
+    Op2 = 1
+    proj1 = [5]
+    proj2 = [2]
+    res = [6]
+    op2 = [:∧₂₁]
+    Σ = 0
+    sum = Int64[]
+    Summand = 0
+    summand = Int64[]
+    summation = Int64[]
+  end
+
   lie_derivative_1 = @decapode begin
     A::DualForm1
     B::Form1
@@ -559,6 +579,26 @@ end
   Decapodes.open_operators!(lie_derivative_1, dimension = 3)
   infer_types!(lie_derivative_1, dim = 3)
   resolve_overloads!(lie_derivative_1, dim = 3)
+
+  @test lie_derivative_1 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 11
+    name = [:A, :B, :C, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3, :Gensim_Var_4, :Gensim_Var_5, :Gensim_Var_6, :Gensim_Var_7, :Gensim_Var_8]
+    type = [:DualForm1, :Form1, :DualForm1, :DualForm2, :DualForm1, :Form1, :Form2, :DualForm0, :Form2, :Form3, :DualForm1]     
+    Op1 = 6
+    src = [1, 4, 7, 1, 10, 8]
+    tgt = [4, 6, 5, 9, 8, 11]
+    op1 = [:dual_d₁, :⋆₁⁻¹, :⋆₂, :⋆₂⁻¹, :⋆₃, :dual_d₀]
+    Op2 = 2
+    proj1 = [9, 6]
+    proj2 = [2, 2]
+    res = [10, 7]
+    op2 = [:∧₂₁, :∧₁₁]
+    Σ = 1
+    sum = [3]
+    Summand = 2
+    summand = [5, 11]
+    summation = [1, 1]
+  end
 
   lie_derivative_2 = @decapode begin
     A::DualForm2
@@ -571,6 +611,26 @@ end
   infer_types!(lie_derivative_2, dim = 3)
   resolve_overloads!(lie_derivative_2, dim = 3)
 
+  @test lie_derivative_2 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 11
+    name = [:A, :B, :C, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3, :Gensim_Var_4, :Gensim_Var_5, :Gensim_Var_6, :Gensim_Var_7, :Gensim_Var_8]
+    type = [:DualForm2, :Form1, :DualForm2, :DualForm3, :DualForm2, :Form0, :Form1, :DualForm1, :Form1, :Form2, :DualForm2]     
+    Op1 = 6
+    src = [1, 4, 7, 1, 10, 8]
+    tgt = [4, 6, 5, 9, 8, 11]
+    op1 = [:dual_d₂, :⋆₀⁻¹, :⋆₁, :⋆₁⁻¹, :⋆₂, :dual_d₁]
+    Op2 = 2
+    proj1 = [9, 6]
+    proj2 = [2, 2]
+    res = [10, 7]
+    op2 = [:∧₁₁, :∧₀₁]
+    Σ = 1
+    sum = [3]
+    Summand = 2
+    summand = [5, 11]
+    summation = [1, 1]
+  end
+
   lie_derivative_3 = @decapode begin
     A::DualForm3
     B::Form1
@@ -582,6 +642,26 @@ end
   infer_types!(lie_derivative_3, dim = 3)
   resolve_overloads!(lie_derivative_3, dim = 3)
 
+  @test lie_derivative_3 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 6
+    name = [:A, :B, :C, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3]
+    type = [:DualForm3, :Form1, :DualForm3, :DualForm2, :Form0, :Form1]
+    Op1 = 3
+    src = [1, 6, 4]
+    tgt = [5, 4, 3]
+    op1 = [:⋆₀⁻¹, :⋆₁, :dual_d₂]
+    Op2 = 1
+    proj1 = [5]
+    proj2 = [2]
+    res = [6]
+    op2 = [:∧₀₁]
+    Σ = 0
+    sum = Int64[]
+    Summand = 0
+    summand = Int64[]
+    summation = Int64[]
+  end
+
   codiff_3 = @decapode begin
     A::Form3
     B::Form2
@@ -592,6 +672,26 @@ end
   infer_types!(codiff_3, dim = 3)
   resolve_overloads!(codiff_3, dim = 3)
 
+  @test codiff_3 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 4
+    name = [:A, :B, :Gensim_Var_1, :Gensim_Var_2]
+    type = [:Form3, :Form2, :DualForm0, :DualForm1]
+    Op1 = 3
+    src = [4, 1, 3]
+    tgt = [2, 3, 4]
+    op1 = [:⋆₂⁻¹, :⋆₃, :dual_d₀]
+    Op2 = 0
+    proj1 = Int64[]
+    proj2 = Int64[]
+    res = Int64[]
+    op2 = Any[]
+    Σ = 0
+    sum = Int64[]
+    Summand = 0
+    summand = Int64[]
+    summation = Int64[]
+  end
+
   laplace_de_rham_0 = @decapode begin
     (A, B)::Form0
 
@@ -600,6 +700,26 @@ end
   Decapodes.open_operators!(laplace_de_rham_0, dimension = 3)
   infer_types!(laplace_de_rham_0, dim = 3)
   resolve_overloads!(laplace_de_rham_0, dim = 3)
+
+  @test laplace_de_rham_0 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 5
+    name = [:A, :B, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3]
+    type = [:Form0, :Form0, :Form1, :DualForm2, :DualForm3]
+    Op1 = 4
+    src = [5, 1, 3, 4]
+    tgt = [2, 3, 4, 5]
+    op1 = [:⋆₀⁻¹, :d₀, :⋆₁, :dual_d₂]
+    Op2 = 0
+    proj1 = Int64[]
+    proj2 = Int64[]
+    res = Int64[]
+    op2 = Any[]
+    Σ = 0
+    sum = Int64[]
+    Summand = 0
+    summand = Int64[]
+    summation = Int64[]
+  end
 
   laplace_de_rham_1 = @decapode begin
     (A, B)::Form1
@@ -610,6 +730,26 @@ end
   infer_types!(laplace_de_rham_1, dim = 3)
   resolve_overloads!(laplace_de_rham_1, dim = 3)
 
+  @test laplace_de_rham_1 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 10
+    name = [:A, :B, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3, :Gensim_Var_4, :Gensim_Var_5, :Gensim_Var_6, :Gensim_Var_7, :Gensim_Var_8]
+    type = [:Form1, :Form1, :Form1, :Form2, :DualForm1, :DualForm2, :Form1, :Form0, :DualForm2, :DualForm3]
+    Op1 = 8
+    src = [8, 1, 4, 5, 6, 1, 9, 10]
+    tgt = [7, 4, 5, 6, 3, 9, 10, 8]
+    op1 = [:d₀, :d₁, :⋆₂, :dual_d₁, :⋆₁⁻¹, :⋆₁, :dual_d₂, :⋆₀⁻¹]
+    Op2 = 0
+    proj1 = Int64[]
+    proj2 = Int64[]
+    res = Int64[]
+    op2 = Any[]
+    Σ = 1
+    sum = [2]
+    Summand = 2
+    summand = [3, 7]
+    summation = [1, 1]
+  end
+
   laplace_de_rham_2 = @decapode begin
     (A, B)::Form2
 
@@ -618,6 +758,26 @@ end
   Decapodes.open_operators!(laplace_de_rham_2, dimension = 3)
   infer_types!(laplace_de_rham_2, dim = 3)
   resolve_overloads!(laplace_de_rham_2, dim = 3)
+
+  @test laplace_de_rham_2 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 10
+    name = [:A, :B, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3, :Gensim_Var_4, :Gensim_Var_5, :Gensim_Var_6, :Gensim_Var_7, :Gensim_Var_8]
+    type = [:Form2, :Form2, :Form2, :Form3, :DualForm0, :DualForm1, :Form2, :Form1, :DualForm1, :DualForm2]
+    Op1 = 8
+    src = [8, 1, 4, 5, 6, 1, 9, 10]
+    tgt = [7, 4, 5, 6, 3, 9, 10, 8]
+    op1 = [:d₁, :d₂, :⋆₃, :dual_d₀, :⋆₂⁻¹, :⋆₂, :dual_d₁, :⋆₁⁻¹]
+    Op2 = 0
+    proj1 = Int64[]
+    proj2 = Int64[]
+    res = Int64[]
+    op2 = Any[]
+    Σ = 1
+    sum = [2]
+    Summand = 2
+    summand = [3, 7]
+    summation = [1, 1]
+  end
 
   laplace_de_rham_3 = @decapode begin
     (A, B)::Form3
@@ -628,5 +788,23 @@ end
   infer_types!(laplace_de_rham_3, dim = 3)
   resolve_overloads!(laplace_de_rham_3, dim = 3)
 
-
+  @test laplace_de_rham_3 == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var = 5
+    name = [:A, :B, :Gensim_Var_1, :Gensim_Var_2, :Gensim_Var_3]
+    type = [:Form3, :Form3, :Form2, :DualForm0, :DualForm1]
+    Op1 = 4
+    src = [3, 1, 4, 5]
+    tgt = [2, 4, 5, 3]
+    op1 = [:d₂, :⋆₃, :dual_d₀, :⋆₂⁻¹]
+    Op2 = 0
+    proj1 = Int64[]
+    proj2 = Int64[]
+    res = Int64[]
+    op2 = Any[]
+    Σ = 0
+    sum = Int64[]
+    Summand = 0
+    summand = Int64[]
+    summation = Int64[]
+  end
 end

--- a/test/simulation_core.jl
+++ b/test/simulation_core.jl
@@ -336,10 +336,10 @@ import Decapodes: UnsupportedDimensionException, UnsupportedStateeltypeException
 
 @testset "Gensim Fuzzing" begin
   let d = @decapode begin end
-    @test_throws UnsupportedDimensionException gensim(d, [:test], dimension = 3, stateeltype = Float64, code_target = CPUTarget())
+    @test_throws UnsupportedDimensionException gensim(d, [:test], dimension = 4, stateeltype = Float64, code_target = CPUTarget())
     @test_throws UnsupportedStateeltypeException gensim(d, [:test], dimension = 2, stateeltype = Int64, code_target = CPUTarget())
 
-    @test_throws UnsupportedDimensionException gensim(d, [:test], dimension = 3, stateeltype = Float64, code_target = CUDATarget())
+    @test_throws UnsupportedDimensionException gensim(d, [:test], dimension = 4, stateeltype = Float64, code_target = CUDATarget())
     @test_throws UnsupportedStateeltypeException gensim(d, [:test], dimension = 2, stateeltype = Int64, code_target = CUDATarget())
   end
 end


### PR DESCRIPTION
This PR is meant to serve as an initial lift to supporting 3D simulations in Decapodes. The initial commit includes an example simulation showcasing heat diffusion in a 3D cube, result shown below. This is based off a test created by @lukem12345 in CombinatorialSpaces.jl. 

https://github.com/user-attachments/assets/e27ea3a7-7f70-45ca-a7fb-ae5262458593

Changes to the Decapodes compiler and various changes/additions to DiagX will have to be made to support simulation generation. This PR can be considered complete once the above simulation can be run in a workflow that is essentially the same as the 2D heat diffusion simulation shown below.

```julia

using Decapodes
using DiagrammaticEquations
using CombinatorialSpaces
using GeometryBasics
using MLStyle
using ComponentArrays
using OrdinaryDiffEq
using Distributions
using CairoMakie

lx = ly = 10
s = triangulated_grid(lx, ly, 0.1, 0.1, Point3D)
sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s)
subdivide_duals!(sd, Circumcenter())

Heat = @decapode begin
    T::Form0
    D::Constant
    ∂ₜ(T) == D * Δ(T)
end

simulate = evalsim(Heat)
  
fₘ = simulate(sd, nothing)

T_dist = MvNormal([lx/2, ly/2], [1, 1])
T = [pdf(T_dist, [p[1], p[2]]) for p in sd[:point]]

D = 0.1

u₀ = ComponentArray(T=T)

constants_and_parameters = (D = D,)

tₑ = 100

prob = ODEProblem(fₘ, u₀, (0, tₑ), constants_and_parameters)
soln = solve(prob, Tsit5())

fig = Figure();
ax = CairoMakie.Axis(fig[1,1])
msh = CairoMakie.mesh!(ax, s, color=soln.u[end].T, colormap=:jet)
Colorbar(fig[1,2], msh)
save("2d_heat.png", fig)
```