### PR TITLE
Fix overview video

### DIFF
--- a/docs/src/overview/overview.md
+++ b/docs/src/overview/overview.md
@@ -290,7 +290,7 @@ constants = ComponentArray(diffusion_k=0.05)
 
 tₑ = 50
 prob = ODEProblem(fₘ, u₀, (0.0, tₑ), constants)
-sol = solve(prob, Tsit5())
+soln = solve(prob, Tsit5())
 
 fig = Figure()
 ax = CairoMakie.Axis(fig[1,1], aspect = AxisAspect(3.0))


### PR DESCRIPTION
The final recording is using the wrong solution object and thus only shows the diffusion physics. I've updated this to have it instead use the diff-adv physics.