### PR TITLE
Fix `FixSizedDiffCache` errors

### DIFF
--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -124,7 +124,7 @@ datatype of the vector, and the `code_target` which is used by multiple dispatch
 An example overloaded hook signature would be `hook_AVC_caching(c::AllocVecCall, resolved_form::Symbol, ::UserTarget)`
 """
 function hook_AVC_caching(c::AllocVecCall, resolved_form::Symbol, ::CPUBackend)
-  :($(Symbol(:__,c.name)) = Decapodes.FixedSizeDiffCache(Vector{$(c.T)}(undef, nparts(mesh, $(QuoteNode(resolved_form))))))
+  :($(Symbol(:__,c.name)) = Decapodes.DiffCache(Vector{$(c.T)}(undef, nparts(mesh, $(QuoteNode(resolved_form))))))
 end
 
 # TODO: Allow user to overload these hooks with user-defined code_target
@@ -504,7 +504,7 @@ end
     hook_PPVA_data_handle!(cache_exprs::Vector{Expr}, alloc_vec::AllocVecCall, ::CPUBackend)
 
 This hook determines if preallocated vectors need to be be handled in a special manner everytime
-before a function run. This is useful in the example of using `FixedSizeDiffCache` from `PreallocationTools.jl`.
+before a function run. This is useful in the example of using `DiffCache` from `PreallocationTools.jl`.
 
 This hook is passed in `cache_exprs` which is the collection of exprs to be pasted, `alloc_vec` which is an
 `AllocVecCall` that stores information about the allocated vector and a code target.

--- a/test/simulation.jl
+++ b/test/simulation.jl
@@ -320,7 +320,7 @@ end
   # arbitrary internal variable naming.
   @test budyko_sellers[only(incident(budyko_sellers, Symbol("•1"), :name)), :type] == :DualForm0
   # A dual 0-form consists of ne(s) floats.
-  @test occursin("var\"__•1\" = Decapodes.FixedSizeDiffCache(Vector{Float64}(undef, nparts(mesh, :E)))",
+  @test occursin("var\"__•1\" = Decapodes.DiffCache(Vector{Float64}(undef, nparts(mesh, :E)))",
     repr(gensim(budyko_sellers, dimension=1)))
 end
 

--- a/test/simulation_core.jl
+++ b/test/simulation_core.jl
@@ -115,7 +115,7 @@ import Decapodes: AllocVecCall
 
   This function tests that the PreallocationTools usage is correct. Exactly, this tests that
   the form to simplex conversion is correct, that the correct collection is used and that the
-  name of the cache is different from the variable. This only works for `FixedSizeDiffCache`.
+  name of the cache is different from the variable. This only works for `DiffCache`.
   """
   function test_prealloc_tools(alloc_vec::AllocVecCall)
     expr = Expr(alloc_vec)
@@ -132,7 +132,7 @@ import Decapodes: AllocVecCall
 
     @test alloc_vec.name != name
 
-    @test cache == :(Decapodes.FixedSizeDiffCache)
+    @test cache == :(Decapodes.DiffCache)
 
     @test type_result == simplex_type
 
@@ -177,12 +177,12 @@ import Decapodes: AllocVecCall
 
   for type in [Float32, Float64]
 
-    # Test correct data for dimension 1 FixedSizeDiffCache
+    # Test correct data for dimension 1 DiffCache
     for form in [:Form0, :Form1, :DualForm1, :DualForm0]
       test_prealloc_tools(AllocVecCall(:V, form, 1, type, CPUTarget()))
     end
 
-    # Test correct data for dimension 2 FixedSizeDiffCache
+    # Test correct data for dimension 2 DiffCache
     for form in [:Form0, :Form1, :Form2, :DualForm2, :DualForm1, :DualForm0]
       test_prealloc_tools(AllocVecCall(:V, form, 2, type, CPUTarget()))
     end


### PR DESCRIPTION
Running the tests with recent versions of `PreallocationTools.jl` results in the following error:
```julia
     Testing Running tests...
ComponentArrays.jl Integration: Error During Test at /Users/runner/work/Decapodes.jl/Decapodes.jl/test/runtests.jl:3
  Got exception outside of a @test
  LoadError: MethodError: no method matching PreallocationTools.FixedSizeDiffCache(::Vector{Float64}, ::Nothing, ::Vector{Any})
  The type `PreallocationTools.FixedSizeDiffCache` exists, but no method is defined for this combination of argument types when trying to construct it.
  
  Closest candidates are:
    PreallocationTools.FixedSizeDiffCache(::T, ::S, ::Vector{Any}) where {T<:AbstractArray, S<:AbstractArray}
     @ PreallocationTools ~/.julia/packages/PreallocationTools/FR1nP/src/PreallocationTools.jl:7
    PreallocationTools.FixedSizeDiffCache(::AbstractArray{T}, ::Any, ::Type{Val{chunk_size}}) where {T, chunk_size}
     @ PreallocationTools ~/.julia/packages/PreallocationTools/FR1nP/src/PreallocationTools.jl:15
    PreallocationTools.FixedSizeDiffCache(::AbstractArray)
     @ PreallocationTools ~/.julia/packages/PreallocationTools/FR1nP/src/PreallocationTools.jl:31
```

Currently, we store buffers for intermediate differential forms using `FixSizedDiffCaches` like so:
```julia
var"__•_1_1" = Decapodes.FixedSizeDiffCache(Vector{Float64}(undef, nparts(mesh, :E)))
```

However, recent updates to `PreallocationTools.jl` evidently return an error with this function call.

A simple direct solution is to us `DiffCache` method instead. This current commit ca05725 performs a global find-and-replace for this method. Further investigation is required, including ensuring that this does not break compatibility with any implicit solvers. A test for such may be added.

EDIT:
Looks like potentially a bug upstream. Not likely to merge this PR as-is.