### PR TITLE
Operator Documentation Table for DEC

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,6 +62,7 @@ makedocs(
         "Variable Types" => "concepts/deca_types.md",
         "Meshes" => "concepts/meshes.md",
         "Custom Operators" => "concepts/generate.md",
+        "DEC Op Table" => "dec_operator_table.md"
     ],
     "Zoo" => Any[
         "Vortices" => "navier_stokes/ns.md",

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -1,43 +1,299 @@
 # Discrete Exterior Calculus Operator Table
 
-Preface: This document is meant to be 
-The reader can find more rigorous definitions in the referenced sources for each operator.
+Preface: This document is meant to provide simplified descriptions of the operators of Discrete Exterior Calculus. The reader can find more rigorous definitions in the referenced sources for each operator.
 
 ## Boundary
 
+### Signature
+
+Decapodes.jl
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ∂(s::HasDeltaSet, x::DualChain{n}) where n
+    dual_boundary(n::Int, s::HasDeltaSet, args...)
+    dual_boundary(::Type{Val{n}}, s::HasDeltaSet, args...) where n
+    dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, x::Int)
+    dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int)
+    dual_boundary_nz(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, x::Int)
+
+CombinatorialSpaces.jl, FastDEC.jl
+
+    dec_boundary(n::Int, sd::HasDeltaSet)
+    dec_p_boundary(::Type{Val{k}}, sd::HasDeltaSet; negate::Bool=false) where {k}
+
 ### Description
 
-Topological/Metric: Topological
+The boundary operator acts on the geometry of the mesh, linearly mapping k-chains to (k-1)-chains. It relates to the important exterior derivative operator via duality, and helps compute the operator through Generalized Stokes' Theorem.
 
-### Algorithmic Properties
+This operator inputs k-chains and outputs (k-1)-chains (or k-manifolds to (k-1)-manifolds in the smooth case). For example, it would input a 1-chain, representing a line, into the two endpoints of that line. This operator has nilpotency, meaning the boundary operator applied to that same geometry is always zero. This property is important in the exterior derivative in preserving geometric invariants and physical conservation laws. 
+
+This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_(k−1) |×|C_k |$, meaning it inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. It does not require global information of the entire mesh to compute it. The computation of this operator is local, topological, and coordiante-free. As the geometric intuition for this matrix calculation is difficult to describe, I recommend further investigation online.
+
+This tool is important in defining the exterior derivative operator through Generalized Stokes' Theorem. This theorem states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. Using this definition and the boundary operator's duality, the exterior derivative is the transpose of the boundary matrix. 
+
+Finally, this operator is natural with respect to discrete pullbacks. This statement means that applying the boundary to simplex X before mapping a form on X to Y is the same as mapping the form on X to Y and then applying the operator to Y. This trait preserves the structure of the mesh under situations like mesh refinement and mesh deformations.
+
+### Important Properties
 
 ∂(∂c)=0 
 
-The formula above displays the property that the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to chains/simplices as well.
+The formula above displays the property of nilpotency for the boundary operator. In other words, the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to discrete chains as well.
 
 ⟨dω, c⟩ = ⟨ω, ∂c⟩
 
-The boundary operator is dual to the exterior derivative. In fact, exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the interior product of a chain and a cochain is synonymous to evaluating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
+The boundary operator is dual to the exterior derivative. In fact, the exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the inner product of a chain and a cochain is synonymous to integrating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
+
+$\partial[v_o, v_1, ..., v_k]=\sum^k_{i=0}(-1)^i[v_o, ..., v_i, ..., v_k]$
+
+The formula above displays how the boundary operator is computed/defined in the discrete setting. The operator inputs a chain with a particular ordering of vertices, where edges may look like $e=[v_0, v_1]$ and faces may look like $σ=[v_0, v_1, v_2]$. Let's assume the operator inputs the triangular face $σ_o=[v_0, v_1, v_2]$ surrounded by the edges $e_0=[v_0, v_1]$, $e_1=[v_1, v_2]$, and $e_2=[v_o, v_2]$. The boundary operator omits the i-th vertex of the face for each iteration. The operation determines the sign of this edge based on if 'i' is even or odd. For this face $σ_o$, the result $∂[v_o, v_1, v_2 ]=[v_1, v_2 ]−[v_o, v_2 ]+[v_o, v_1 ]=e_1−e_2+e_o$. If the reader creates a visual representation of the face and surrounding vertices, with orientations going from the first vertex and moving to the last, the result will be the same.
 
 ### Citations
 
+Discrete Exterior Calculus - Hirani
+Section 3.6 (pp. 35-36)
+
+Discrete Exterior Calculus - Desbrun
+Section 5 (pp. 13-14)
+
 Notes on Discrete Exterior Calculus
-Page 10
+Section 2.6 (p. 10)
 
-Discrete Exterior Calculus
-Section 4.1 (pp. 40-41)
+Discrete Differential Forms
+Section 3 
 
-ssssssss
+## Exterior Derivative
+
+### Signature
+
+Decapodes.jl
+    
+    :d₀ => dec_differential(0, sd) |> matmul
+    :d₁ => dec_differential(1, sd) |> matmul
+    :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
+    :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
+
+    # Dual Differentials
+    :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
+    :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    d(s::HasDeltaSet, x::DualForm{n}) where n
+    dual_derivative(n::Int, s::HasDeltaSet, args...) dual_derivative(::Type{Val{n}}, s::HasDeltaSet, args...) where n
+    dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex1D, x::Int) dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, x::Int) dual_derivative_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int)
+
+CombinatorialSpaces.jl, FastDEC.jl
+
+    dec_differential(n::Int, sd::HasDeltaSet)
+    dec_dual_derivative(n::Int, sd::HasDeltaSet)
+    dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet1D)
+    dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet2D)
+    dec_p_dual_derivative(::Type{Val{1}}, sd::HasDeltaSet2D)
+    dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet3D)
+    dec_p_dual_derivative(::Type{Val{1}}, sd::HasDeltaSet3D)
+    dec_p_dual_derivative(::Type{Val{2}}, sd::HasDeltaSet3D)
+    dec_p_derivbound(::Type{Val{0}}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
+    dec_p_derivbound(::Type{Val{1}}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
+    dec_p_derivbound(::Type{Val{2}}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
+
+### Description
+
+The exterior derivative operator (ED) extends the idea of differentiation into differential geometry. It generalizes vector calculus concepts such as gradient, divergence, and curl onto multidimensional forms. It is a requirement for modelling any partial differential equation in an exterior calculus framework.
+
+This operator maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the ED operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. The ED on a 3-form in 3D space is always zero.
+
+This operator matrix is calculated with Generalized Stokes' Theorem, which states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. In the discrete setting, the exterior derivative for a cochain is the transpose of the boundary matrix operator for its respective chain. Like the boundary operator, it is a sparse matrix with elements 0, +1, and -1. The computation of this operator is local, topological, and coordiante-free.
+
+Using geometric intuition, this operator determines the dimensional rate of change of a form based on the values of the forms around it. For example, imagine three cochains attatched to 1-simplexes (lines) that form a triangle. The exterior derivative of the 1-cochain formed from the three values is a 2-cochain residing on the triangular face, calculated by adding the cochains together and accounting for differing orientation.
+
+Furthermore, the exterior derivative shares the property of nilpotency with its dual operator. Thus, the exterior derivative applied twice to the same form is always zero. This trait ingrains geometrical information and mathematical conservation properties, such as the curl of a form's divergence always being zero. 
+
+On a dual mesh, the discrete exterior derivative may change in sign to account for the mesh's differing orientation. This formula is displayed in the Important Properties section.
+
+Finally, this operator is natural with respect to discrete pullbacks, like the boundary. It also has an adjoint with the codifferential operator, allowing for Laplacians and Hodge decompositions.
+
+### Important Properties
+
+k-form $-->$ (k+1)-form
+
+$d(dω)=0$
+
+This is the property that the exterior derivative applied twice to the same form is always zero. This property retains the mathematical properties of $∇×∇f=0$ and $∇ ⋅∇×f=0$ without requiring any additional features. 
+
+$d(ω∧β)=dω∧β+(−1)^{deg⁡(ω)}  ω∧β$
+
+The formula above displays the Leibniz Principle of exterior derivatives. It shows how the operator interacts with the wedge product.
+
+$d=∂^T$
+
+In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs k-forms and outputs the exterior derivative values of (k+1)-forms.
+
+$d_{n−k}^{Dual}=(−1)^k (d_{k−1}^{Primal} )^T$
+
+Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction.
+
+$\int_\Omega d\omega=\int_{\partial\Omega}\omega$
+
+The formula above is Generalized Stokes' Theorem. It states that a person can determine the exterior derivative of a form across a manifold by determining the value of that across the boundary of the manifold. As the exterior derivative generalizes the gradient, divergence, and the curl. Generalized Stokes' Theorem combines Stokes' Theorem, Green's Theorem, and the Divergence Theorem into one expression.
+
+### Citations
+
+Discrete Exterior Calculus - Hirani
+Section 3.6 (pp. 35-37)
+
+Discrete Exterior Calculus - Desbrun
+Section 5 (pp. 13)
+
+Notes on Discrete Exterior Calculus
+Section 2.6 (p. 10-11)
+
+Discrete Differential Forms
+Section 4.1-4.3
+
+## Wedge Product
+
+### Signature
+
+### Description
+
+### Important Properties
+
+### Citations
+
+
+## Hodge Star
+
+### Signature
+
+### Description
+
+### Important Properties
+
+### Citations
 
 
 
-- Heelllllooooo
-- Goooodbyeeee
+## Flat
 
-1) Hello
-2) Hello
-3) 000
-4) Goodbye
+### Signature
 
-$$ \sigma^1 \sum_{12} $$
+### Description
 
+### Important Properties
+
+### Citations
+
+
+## Sharp
+
+### Signature
+
+### Description
+
+### Important Properties
+
+### Citations
+
+
+
+## Codifferential
+
+### Signature
+
+### Description
+
+### Important Properties
+
+### Citations
+
+
+## Interior Product
+
+### Signature
+
+### Description
+
+### Important Properties
+
+### Citations
+
+
+## Lie Derivative
+
+### Signature
+
+### Description
+
+### Important Properties
+
+### Citations
+
+
+## Laplace-Beltrami
+
+### Signature
+
+Decapodes.jl
+
+    :Δ₀ => add_De_Rham_1D!(Val{0}, ...)  # dδ + δd → expands to full Laplace–de Rham
+    :Δ₁ => add_De_Rham_1D!(Val{1}, ...) or add_De_Rham_2D!(Val{1}, ...)
+    :Δ₂ => add_De_Rham_2D!(Val{2}, ...)
+    
+    :Δᵈ₀ => Δᵈ(Val{0}, sd)               # Dual 0-form Laplacian (fast version)
+    :Δᵈ₁ => Δᵈ(Val{1}, sd)               # Dual 1-form Laplacian
+    
+    :Δ₀⁻¹ => dec_inv_lap_solver(Val{0}, sd)  # factorize(∇²(0, sd)) \ x
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ∇²(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
+    ∇²(n::Int, s::HasDeltaSet, args...; kw...)
+    ∇²(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; kw...) where n
+    ∇²(::Type{Val{n}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n
+    
+    Δ(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
+    Δ(n::Int, s::HasDeltaSet, args...; kw...)
+    Δ(::Type{Val{0}}, s::HasDeltaSet, form::AbstractVector; kw...)
+    Δ(::Type{Val{0}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...)
+    Δ(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; kw...) where n
+    Δ(::Type{Val{n}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n
+    Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, form::AbstractVector; kw...)
+    Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...)
+    Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector; kw...)
+    Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...)
+    
+CombinatorialSpaces.jl, FastDEC.jl
+
+    Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet)
+    Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet2D)
+    Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet3D)
+    Δᵈ(::Type{Val{1}}, s::SimplicialSets.HasDeltaSet)
+    dec_Δ⁻¹(::Type{Val{0}}, s::AbstractGeometricMapSeries; scheme::AbstractSubdivisionScheme = BinarySubdivision(), steps = 3, cycles = 5, alg = cg, μ = 2)
+
+
+### Description
+
+The Laplace-Beltrami operator generalizes the traditional Laplacian to curved surfaces. It linearly maps k-forms to k-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the functions surrounding it. A positive Laplacian implies that the point is less than the surrounding average (or convex down), while a negative one implies the point is greater than the surrounding average (or convex up).
+
+This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies to $δd$, as the exterior codifferential of a 0-form is always zero.
+
+It is represented as a sparse matrix. Due to its reliance on the codifferential (and thus the hodge star), it is metric-dependent. 
+
+### Important Properties
+
+k-form → k-form
+
+Δ=dδ+δd
+This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, ∇f=δdf, is a special situation for 0-form functions, where d(δf)=0 as the codifferential of a 0-form is always zero.
+
+⟨Δf, σ^0 ⟩=1/|⋆σ^0 |  ∑_(σ^1=[σ^0, v])▒〖|⋆σ^1 |/|σ^1 | (f(v)−f(σ^0 ))〗
+This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex σ^0  (⟨Δf, σ^0 ⟩) can be evaluated by the sum/contribution of all edges bordering σ^0, each weighted by the length of their corresponding dual edge divded by their primal length (|⋆σ^1 |/|σ^1 | ), and then multiplied by the difference between the form at the evaluated vertex (f(σ^0)) and the neighboring vertex (f(v)), connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell (1/|⋆σ^0 | ) to normalize it. This formula matches with another geometric Laplace-Beltrami formula that uses cotangents and indices.
+
+### Citations
+
+Discrete Exterior Calculus - Hirani
+Section 6.4 (pp. 68-70)
+
+Discrete Exterior Calculus - Desbrun
+Section 10 (pp. 26-27)

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -117,23 +117,23 @@ Finally, this operator is natural with respect to discrete pullbacks, like the b
 
 k-form $-->$ (k+1)-form
 
-$d(dω)=0$
+$ d(dω)=0 $
 
 This is the property that the exterior derivative applied twice to the same form is always zero. This property retains the mathematical properties of $∇×∇f=0$ and $∇ ⋅∇×f=0$ without requiring any additional features. 
 
-$d(ω∧β)=dω∧β+(−1)^{deg⁡(ω)}  ω∧β$
+$ d(ω∧β)=dω∧β+(−1)^{deg⁡(ω)} ω∧β $
 
 The formula above displays the Leibniz Principle of exterior derivatives. It shows how the operator interacts with the wedge product.
 
-$d=∂^T$
+$ d=∂^T $
 
 In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs k-forms and outputs the exterior derivative values of (k+1)-forms.
 
-$d_{n−k}^{Dual}=(−1)^k (d_{k−1}^{Primal} )^T$
+$ d_{n−k}^{Dual} = (−1)^k (d_{k−1}^{Primal} )^T $
 
 Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction.
 
-$\int_\Omega d\omega=\int_{\partial\Omega}\omega$
+$ \int_\Omega d\omega=\int_{\partial\Omega}\omega $
 
 The formula above is Generalized Stokes' Theorem. It states that a person can determine the exterior derivative of a form across a manifold by determining the value of that across the boundary of the manifold. As the exterior derivative generalizes the gradient, divergence, and the curl. Generalized Stokes' Theorem combines Stokes' Theorem, Green's Theorem, and the Divergence Theorem into one expression.
 
@@ -225,7 +225,6 @@ Finally, the Leibniz Rule displays an important relationship between the wedge p
 $ deg⁡(ω)+deg⁡(β)=deg⁡(ω∧β) $
 
 The wedge product combines a k-form and a p-form and creates a (k+p)-form.
-
 
 $ 
 \langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
@@ -421,9 +420,14 @@ $⟨X, v⟩=X^♭ (v)$
 
 The formula above displays the definition of the smooth flat operator. The inner product of the vector field with another vector should be equivalent to the vector 
 
-$ ⟨X^(♭_{dpp} ), σ^1 ⟩ = ∑_{σ^n≻ σ^1}▒〖|∗σ^1∩σ^n |/|∗σ^1 |  X(σ^n )⋅(σ^1 ) ̃ 〗$
 
-The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge (∑_(σ^n≻ σ^1)▒ ), determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell (|∗σ^1∩σ^n |/|∗σ^1 | ). Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge (X(σ^n )⋅(σ^1 ) ̃). Finally, sum all contibutions.
+
+$ \langle X^{\flat_{dpp}}, \sigma^1 \rangle =
+\sum_{\sigma^n \succ \sigma^1} \frac{\star \sigma^1 \cap \sigma^n |}{| \star \sigma^1 |}
+X(\sigma^n)\cdot \tilde{\sigma^1}
+$
+
+The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge $(∑_{σ^n≻ σ^1} )$, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell $( |∗σ^1 ∩ σ^n |/|∗ σ^1 | )$. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge $(X(\sigma^n) \cdot \tilde{\sigma^1})$. Finally, sum all contibutions.
 
 ### Citations
 

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -2,6 +2,20 @@
 
 Preface: This document is meant to provide simplified descriptions of the operators of Discrete Exterior Calculus. The reader can find more rigorous definitions in the referenced sources for each operator.
 
+Here are the links to the sources referenced for the operators below:
+
+Discrete Exterior Calculus - Hirani
+https://www.cs.jhu.edu/~misha/Fall09/Hirani03.pdf
+
+Discrete Exterior Calculus - Desbrun et. al.
+https://arxiv.org/abs/math/0508341
+
+Notes on Discrete Exterior Calculus - Gillette
+https://math.arizona.edu/~agillette/research/decNotes.pdf
+
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
+https://geometry.caltech.edu/pubs/DKT05.pdf
+
 ## Boundary
 
 ### Signature
@@ -28,7 +42,7 @@ The boundary operator acts on the geometry of the mesh, linearly mapping k-chain
 
 This operator inputs k-chains and outputs (k-1)-chains (or k-manifolds to (k-1)-manifolds in the smooth case). For example, it would input a 1-chain, representing a line, into the two endpoints of that line. This operator has nilpotency, meaning the boundary operator applied to that same geometry is always zero. This property is important in the exterior derivative in preserving geometric invariants and physical conservation laws. 
 
-This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_(k−1) |×|C_k |$, meaning it inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. It does not require global information of the entire mesh to compute it. The computation of this operator is local, topological, and coordiante-free. As the geometric intuition for this matrix calculation is difficult to describe, I recommend further investigation online.
+This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_{k−1} |×|C_k |$, meaning it inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. It does not require global information of the entire mesh to compute it. The computation of this operator is local, topological, and coordinate-free. As the geometric intuition for this matrix calculation is difficult to describe, I recommend further investigation online.
 
 This tool is important in defining the exterior derivative operator through Generalized Stokes' Theorem. This theorem states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. Using this definition and the boundary operator's duality, the exterior derivative is the transpose of the boundary matrix. 
 
@@ -36,15 +50,19 @@ Finally, this operator is natural with respect to discrete pullbacks. This state
 
 ### Important Properties
 
-∂(∂c)=0 
+$C_k(K; \Z) \rightarrow C_{k - 1} (K; \Z) $
+
+The boundary operator linearly inputs linear combinations of k-chains (integers with respect to simplex orientation, represented by $ \Z $) on mesh K and outputs the combined (k-1)-chain sum of the boundary of those k-chains.
+
+$ ∂(∂c) = 0 $
 
 The formula above displays the property of nilpotency for the boundary operator. In other words, the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to discrete chains as well.
 
-⟨dω, c⟩ = ⟨ω, ∂c⟩
+$ ⟨dω, c⟩ = ⟨ω, ∂c⟩ $
 
 The boundary operator is dual to the exterior derivative. In fact, the exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the inner product of a chain and a cochain is synonymous to integrating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
 
-$\partial[v_o, v_1, ..., v_k]=\sum^k_{i=0}(-1)^i[v_o, ..., v_i, ..., v_k]$
+$ \partial[v_o, v_1, ..., v_k] = \sum^k_{i=0}(-1)^i[v_o, ..., v_i, ..., v_k] $
 
 The formula above displays how the boundary operator is computed/defined in the discrete setting. The operator inputs a chain with a particular ordering of vertices, where edges may look like $e=[v_0, v_1]$ and faces may look like $σ=[v_0, v_1, v_2]$. Let's assume the operator inputs the triangular face $σ_o=[v_0, v_1, v_2]$ surrounded by the edges $e_0=[v_0, v_1]$, $e_1=[v_1, v_2]$, and $e_2=[v_o, v_2]$. The boundary operator omits the i-th vertex of the face for each iteration. The operation determines the sign of this edge based on if 'i' is even or odd. For this face $σ_o$, the result $∂[v_o, v_1, v_2 ]=[v_1, v_2 ]−[v_o, v_2 ]+[v_o, v_1 ]=e_1−e_2+e_o$. If the reader creates a visual representation of the face and surrounding vertices, with orientations going from the first vertex and moving to the last, the result will be the same.
 
@@ -53,13 +71,13 @@ The formula above displays how the boundary operator is computed/defined in the 
 Discrete Exterior Calculus - Hirani  
 Section 3.6 (pp. 35-36)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 5 (pp. 13-14)
 
-Notes on Discrete Exterior Calculus  
+Notes on Discrete Exterior Calculus - Gillette  
 Section 2.6 (p. 10)
 
-Discrete Differential Forms  
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
 Section 3 
 
 ## Exterior Derivative
@@ -72,8 +90,6 @@ Decapodes.jl
     :d₁ => dec_differential(1, sd) |> matmul
     :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
     :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
-
-    # Dual Differentials
     :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
     :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
 
@@ -103,25 +119,27 @@ The exterior derivative operator (ED) extends the idea of differentiation into d
 
 This operator maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the ED operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. The ED on a 3-form in 3D space is always zero.
 
-This operator matrix is calculated with Generalized Stokes' Theorem, which states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. In the discrete setting, the exterior derivative for a cochain is the transpose of the boundary matrix operator for its respective chain. Like the boundary operator, it is a sparse matrix with elements 0, +1, and -1. The computation of this operator is local, topological, and coordiante-free.
+This operator matrix is calculated with Generalized Stokes' Theorem, which states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. In the discrete setting, the exterior derivative for a cochain is the transpose of the boundary matrix operator for its respective chain. Like the boundary operator, it is a sparse matrix with elements 0, +1, and -1. The computation of this operator is local, topological, and coordinate-free.
 
-Using geometric intuition, this operator determines the dimensional rate of change of a form based on the values of the forms around it. For example, imagine three cochains attatched to 1-simplexes (lines) that form a triangle. The exterior derivative of the 1-cochain formed from the three values is a 2-cochain residing on the triangular face, calculated by adding the cochains together and accounting for differing orientation.
+Using geometric intuition, this operator determines the dimensional rate of change of a form based on the values of the forms around it. For example, imagine three cochains attached to 1-simplexes (lines) that form a triangle. The exterior derivative of the 1-cochain formed from the three values is a 2-cochain residing on the triangular face, calculated by adding the cochains together and accounting for differing orientation.
 
 Furthermore, the exterior derivative shares the property of nilpotency with its dual operator. Thus, the exterior derivative applied twice to the same form is always zero. This trait ingrains geometrical information and mathematical conservation properties, such as the curl of a form's divergence always being zero. 
 
 On a dual mesh, the discrete exterior derivative may change in sign to account for the mesh's differing orientation. This formula is displayed in the Important Properties section.
 
-Finally, this operator is natural with respect to discrete pullbacks, like the boundary. It also has an adjoint with the codifferential operator, allowing for Laplacians and Hodge decompositions.
+Finally, this operator is natural with respect to discrete pullbacks, like the boundary. It also has an adjoint with the codifferential operator, allowing for the Laplacian and Hodge decompositions.
 
 ### Important Properties
 
-k-form $-->$ (k+1)-form
+$ \Omega_d^k (K) \rightarrow \Omega_d^{p + 1} (K) $
+
+The discrete exterior derivative linearly maps discrete k-forms on mesh K to discrete (k+1)-forms on the same mesh K.
 
 $ d(dω)=0 $
 
 This is the property that the exterior derivative applied twice to the same form is always zero. This property retains the mathematical properties of $∇×∇f=0$ and $∇ ⋅∇×f=0$ without requiring any additional features. 
 
-$ d(ω∧β)=dω∧β+(−1)^{deg⁡(ω)} ω∧β $
+$ d(ω∧β) = dω ∧ β+(−1)^{deg⁡(ω)} ω ∧ β $
 
 The formula above displays the Leibniz Principle of exterior derivatives. It shows how the operator interacts with the wedge product.
 
@@ -129,9 +147,9 @@ $ d=∂^T $
 
 In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs k-forms and outputs the exterior derivative values of (k+1)-forms.
 
-$ d_{n−k}^{Dual} = (−1)^k (d_{k−1}^{Primal} )^T $
+$ \tilde{d}_{n−k} = (−1)^k (d_{k−1} )^T $
 
-Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction.
+Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction, where $\tilde{d} $ represents the dual exterior derivative operator.
 
 $ \int_\Omega d\omega=\int_{\partial\Omega}\omega $
 
@@ -142,13 +160,13 @@ The formula above is Generalized Stokes' Theorem. It states that a person can de
 Discrete Exterior Calculus - Hirani  
 Section 3.6 (pp. 35-37)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 5 (pp. 13)
 
-Notes on Discrete Exterior Calculus  
+Notes on Discrete Exterior Calculus - Gillette   
 Section 2.6 (p. 10-11)
 
-Discrete Differential Forms  
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
 Section 4.1-4.3
 
 ## Wedge Product
@@ -162,12 +180,10 @@ Decapodes.jl
     :∧₀₂ => dec_pair_wedge_product(Tuple{0,2}, sd)
     :∧₂₀ => dec_pair_wedge_product(Tuple{2,0}, sd)
     :∧₁₁ => dec_pair_wedge_product(Tuple{1,1}, sd)
-    
     :∧ᵖᵈ₁₁ => dec_wedge_product_pd(Tuple{1,1}, sd)
     :∧ᵖᵈ₀₁ => dec_wedge_product_pd(Tuple{0,1}, sd)
     :∧ᵈᵖ₁₁ => dec_wedge_product_dp(Tuple{1,1}, sd)
     :∧ᵈᵖ₁₀ => dec_wedge_product_dp(Tuple{1,0}, sd)
-    
     :∧ᵈᵈ₁₁ => dec_wedge_product_dd(Tuple{1,1}, sd)
     :∧ᵈᵈ₁₀ => dec_wedge_product_dd(Tuple{1,0}, sd)
     :∧ᵈᵈ₀₁ => dec_wedge_product_dd(Tuple{0,1}, sd)
@@ -212,19 +228,19 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The wedge product operator is used to "combine" a k-form and an l-form into a higher degree (k+l)-form. As an example, imagine two vector-like 1-cochains. The wedge product would be the signed area formed by dragging one of the forms across the other, like a determinant. For this reason, the wedge product has nilpotency, where the wedge product of the same form $(ω∧ω=0)$ is likely zero.
+The wedge product operator is used to "combine" a k-form and an l-form into a higher degree (k+l)-form. As an example, imagine two vector-like 1-cochains. The wedge product would be the signed area formed by dragging one of the forms across the other, like a determinant.
 
-It is an anticommutative operator, meaning $β∧ω$ is often equal to $−ω∧β$ under most circumstances. It is also associative, meaning $(ω∧β)∧γ=ω∧(β∧γ)$. In the discrete case however, the associative property is limitted to only closed forms. The exterior derivative of closed forms is always zero. Later operators which use this tool as a component also face this limitation.
+It is an anti-commutative operator, meaning $β∧ω$ is often equal to $−ω∧β$ under most circumstances. It is also associative, meaning $(ω∧β)∧γ=ω∧(β∧γ)$. In the discrete case however, the associative property is limited to only closed forms. The exterior derivative of closed forms is always zero. Later operators which use this tool as a component also face this limitation.
 
 Another limitation is the wedge product's reliance on the metric. Certain operator formulas may require defined angles for calculating the result of this operator. However, other formulas may lack this limitation. Formulas that are not metric-dependent are natural with respect to discrete pullbacks.
 
-Finally, the Leibniz Rule displays an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas. 
+Finally, the Leibniz Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas. 
 
 ### Important Properties
 
-$ deg⁡(ω)+deg⁡(β)=deg⁡(ω∧β) $
+$ \Omega^k_d (K) \times \Omega^l_d (K) \rightarrow \Omega^{k + l}_d (K) $
 
-The wedge product combines a k-form and a p-form and creates a (k+p)-form.
+The discrete primal-primal wedge product inputs a discrete primal k-form and discrete primal l-form on mesh K and outputs a discrete (k+l)-form on mesh K. The discrete dual-dual wedge product and discrete primal-dual wedge product would be defined differently.
 
 $ 
 \langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
@@ -234,7 +250,7 @@ $
 \langle \beta, [v_{\tau(k)}, ..., v_{\tau(k+l)}] \rangle 
 $
 
-This is the metric formulation for the discrete primal-primal wedge product operator, where ω is a is a discrete primal k-form and β is a discrete primal l-form. The LHS states that the evaluation of the wedge product of two forms on the appropraite face is equal to the RHS. The RHS states that for each permutation of the simplex $σ^{k+l}$  (where there are $(k+l+1)!$  orderings of the vertices), it finds the sign of that permutation $(sign(τ))$ and multiplies it by a geometric weight $(|σ^{k+l}∩⋆v_τ (k)| / |σ^(k+l) | )$. The weight determines the volume of the new simplex that is shared by the simplices touching the k-th vertex of the current permutation, divided by the volume of the new simplex. Finally, it multiplies this weight by the inner product of ω on a k-simplex formed from initial vertices $(⟨ω, [v_τ(0) , …, v_τ(k) ]⟩)$ and the inner product of β on a l-simplex formed from the vertices afterwards $(⟨β, [v_τ(k) , …, v_τ(k+l) ]⟩)$. The contributions from each permutation are summed together and normalized based on the forms' dimensions $(1/(k+l)!)$. As this formula relies on simplex magnitudes, it is metric.
+This is the metric formulation for the discrete primal-primal wedge product operator, where ω is a is a discrete primal k-form and β is a discrete primal l-form. The LHS states that the evaluation of the wedge product of two forms on the appropriate face is equal to the RHS. The RHS states that for each permutation of the simplex $σ^{k+l}$  (where there are $(k+l+1)!$  orderings of the vertices), it finds the sign of that permutation $(sign(τ))$ and multiplies it by a geometric weight $(|σ^{k+l}∩⋆v_τ (k)| / |σ^(k+l) | )$. The weight determines the volume of the new simplex that is shared by the simplices touching the k-th vertex of the current permutation, divided by the volume of the new simplex. Finally, it multiplies this weight by the inner product of ω on a k-simplex formed from initial vertices $(⟨ω, [v_τ(0) , …, v_τ(k) ]⟩)$ and the inner product of β on a l-simplex formed from the vertices afterwards $(⟨β, [v_τ(k) , …, v_τ(k+l) ]⟩)$. The contributions from each permutation are summed together and normalized based on the forms' dimensions $(1/(k+l)!)$. As this formula relies on simplex magnitudes, it is metric.
 
 $ 
 \langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
@@ -254,16 +270,20 @@ $ (ω∧β)∧γ=ω∧(β∧γ) $
 
 This formula displays the associative property of the wedge product operator in the smooth case. In the discrete case, this is only true for closed forms. The exterior derivative of a closed form is zero.
 
-$ ω∧ω=0 $
+$ d(ω∧β) = dω ∧ β+(−1)^{deg⁡(ω)} ω ∧ β $
 
-This formula shows the nilpotency property of wedge product in the smooth case. Consider two differing 1-forms, ω and β, which can be considered dual to vectors. Then, think of the wedge product as an operator which finds the signed area of the parallelogram created by smearing one of those vectors across the edge of the other. If those two forms were in the same direction, like two ω forms, the smearing would only create a line with an area of zero.
+As displayed in the exterior derivative section, the Leibniz Rule underscores the interaction between the exterior derivative and the wedge product operators. 
+
+$ ω ∧ ω = 0 $
+
+This formula shows the alternating property of wedge product in the smooth case. Due to its antisymmetric nature, the wedge product of two equivalent, even-dimensioned forms is always zero.
 
 ### Citations
 
 Discrete Exterior Calculus - Hirani  
 Section 7.1-7.3 (pp. 71-76)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 8 (pp. 17-21)
 
 ## Hodge Star
@@ -275,9 +295,8 @@ Decapodes.jl
     :⋆₀ => dec_hodge_star(0, sd, hodge=hodge) |> matmul
     :⋆₁ => dec_hodge_star(1, sd, hodge=hodge) |> matmul
     :⋆₂ => dec_hodge_star(2, sd, hodge=hodge) |> matmul
-    
     :⋆₀⁻¹ => dec_inv_hodge_star(0, sd, hodge) |> matmul
-    :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge)  # Special: returns (in-place, out-of-place) solver
+    :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge)  
     :⋆₂⁻¹ => dec_inv_hodge_star(1, sd, hodge) |> matmul
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
@@ -337,7 +356,7 @@ CombinatorialSpaces.jl, FastDEC.jl
     dec_inv_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge)
     dec_inv_hodge_star(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge)
     dec_inv_hodge_star(::Type{Val{3}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge)
-dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) where {j}
+    dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) where {j}
 
 ### Description
 
@@ -353,11 +372,13 @@ Finally, as this operator is metric-dependent, it does not commute fully with re
 
 ### Important Properties
 
-k-form → (n-k)-form
+$ \Omega^k_d (K) \rightarrow \Omega^{n - k}_d (\star K) $
 
-$ ⟨ω^k, β^k ⟩v=ω^k∧⋆β^k $
+The discrete hodge star linearly maps discrete k-forms on mesh K to discrete (n-k)-forms on dual mesh $ \star $ K, where n is the number of dimensions of the space.
 
-The formula above displays the identity of the hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the righthand side. Due to this definition, it is inherantly a metric-dependent operator.
+$ ⟨ω^k, β^k ⟩v = ω^k∧⋆β^k $
+
+The formula above displays the identity of the hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the right-hand side. Due to this definition, it is inherently a metric-dependent operator.
 
 $ 
 \frac{1}{|⋆σ^k |}  
@@ -376,13 +397,13 @@ The hodge star operator is an isomorphism. Using the hodge star on a form twice 
 Discrete Exterior Calculus - Hirani  
 Section 4.1 (pp. 40-42)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.
 Section 6 (pp. 14-15)
 
-Notes on Discrete Exterior Calculus  
+Notes on Discrete Exterior Calculus - Gillette  
 Section 2.9 (pp. 12-13)
 
-Discrete Differential Forms  
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
 Section 5.3-5.4
 
 ## Flat
@@ -391,8 +412,8 @@ Section 5.3-5.4
 
 Decapodes.jl
 
-    :♭ᵈᵖ => dec_♭(sd)                    # Dual-to-primal flat
-    :♭♯ => ♭♯_mat(sd) |> matmul          # Dual 1-form → primal 1-form interpolation
+    :♭ᵈᵖ => dec_♭(sd)                    
+    :♭♯ => ♭♯_mat(sd) |> matmul          
 
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
@@ -414,30 +435,26 @@ The smooth definition of the flat operator is reliant on an inner product, makin
 
 ### Important Properties
 
-k-vector → k-form
+$ ⟨X, v⟩ = X^♭ (v)$
 
-$⟨X, v⟩=X^♭ (v)$
-
-The formula above displays the definition of the smooth flat operator. The inner product of the vector field with another vector should be equivalent to the vector 
-
-
+The formula defines displays the flat operator in the smooth case. The inner product of a vector field X with a second vector field v is equivalent to the inner product $ X^♭ (v) = \langle \rangle $ at every point of the Riemannian manifold M with metric $ \langle \rangle $.
 
 $ \langle X^{\flat_{dpp}}, \sigma^1 \rangle =
 \sum_{\sigma^n \succ \sigma^1} \frac{\star \sigma^1 \cap \sigma^n |}{| \star \sigma^1 |}
 X(\sigma^n)\cdot \tilde{\sigma^1}
 $
 
-The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge $(∑_{σ^n≻ σ^1} )$, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell $( |∗σ^1 ∩ σ^n |/|∗ σ^1 | )$. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge $(X(\sigma^n) \cdot \tilde{\sigma^1})$. Finally, sum all contibutions.
+The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge $(∑_{σ^n≻ σ^1} )$, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell $( |∗σ^1 ∩ σ^n |/|∗ σ^1 | )$. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge $(X(\sigma^n) \cdot \tilde{\sigma^1})$. Finally, sum all contributions.
 
 ### Citations
 
 Discrete Exterior Calculus - Hirani  
 Section 5.3-5.6 (pp. 46-54)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.
 Section 7 (p. 16)
 
-Notes on Discrete Exterior Calculus  
+Notes on Discrete Exterior Calculus - Gillette 
 Section 2.12 (pp. 14-15)
 
 ## Sharp
@@ -446,9 +463,9 @@ Section 2.12 (pp. 14-15)
 
 Decapodes.jl
 
-    :♯ᵖᵈ => dec_♯_pd(sd)                 # Primal-dual sharp (1D only)
-    :♯ᵖᵖ => dec_♯_pp(sd)                 # Primal-primal sharp (AltPPSharp in 2D)
-    :♯ᵈᵈ => dec_♯_dd(sd)                 # Dual-dual sharp (LLSDDSharp)
+    :♯ᵖᵈ => dec_♯_pd(sd)                 
+    :♯ᵖᵖ => dec_♯_pp(sd)                 
+    :♯ᵈᵈ => dec_♯_dd(sd)                 
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
 
@@ -478,18 +495,16 @@ The sharp vector turns k-forms into k-vectors. In the smooth case, it is inverse
 
 ### Important Properties
 
-k-form → k-vector
+$ ⟨ω^{\sharp}, v⟩ = ω(v) $
 
-$ ⟨ω^{\sharp}, v⟩= ω(v) $
-
-The formula above displays the definition of the smooth sharp operator. The inner product of the sharped form with a different vector should be equivalent to the vector being inputted into the regular form.
+The formula defines the sharp operator map in the smooth case. The inner product $\omega^{\sharp}$ with vector field v is equivalent to the output of form $ \omega $ with the input v. This should be the case for all points in Riemannian manifold M.
 
 ### Citations
 
-Discrete Exterior Calculus  
+Discrete Exterior Calculus - Hirani  
 Chapter 5.7-5.8 (pp. 54-56)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 7 (p. 16)
 
 ## Codifferential
@@ -498,7 +513,7 @@ Section 7 (p. 16)
 
 Decapodes.jl
 
-    :δ₁ => add_Codiff!(d, src, tgt)  # Expands to ⋆ → d → ⋆ (with correct dual/primal flips)
+    :δ₁ => add_Codiff!(d, src, tgt)  
     :δ₂ => add_Codiff!(d, src, tgt)
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
@@ -515,26 +530,29 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The codifferential operator serves as the adjoint of the exterior derivative. It maps k-forms to (k-1)-forms. This operator is used to represent divergence and as a component of the Laplace-Beltrami operator.
+The codifferential operator serves as the adjoint of the exterior derivative. It maps k-forms to (k-1)-forms. This operator is used to represent divergence and as a component of the Laplace-Beltrami (Laplacian) operator.
 
-This operator is metric due to the reliance of the hodge star in its defintion. It is represented as a sparse matrix created by combining hodge star and exterior derivative matrices and accounting for orientation. 
+This operator is metric due to the reliance of the hodge star in its definition. It is represented as a sparse matrix created by combining hodge star and exterior derivative matrices and accounting for orientation. 
 
-In the smooth setting, the codifferential is the adjoint of the exterior derivative operator. This property is retained in the discrete setting as well. It is defined through hodge star and exterior derivative operators. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation. This operator is also used as a part of the algebraic definition of the Laplace-Beltrami operator. 
+In the smooth setting, the codifferential is the adjoint of the exterior derivative operator. This property is retained in the discrete setting as well. It is defined through hodge star and exterior derivative operators. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation. This operator is also used as a part of the algebraic definition for the Laplace-Beltrami operator. 
 
-Finally, due to the prescence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. Due to inaccuracies in the discrete hodge star, the discrete codifferential applied twice is approximately zero.
+Finally, due to the presence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. Due to inaccuracies in the discrete hodge star, the discrete codifferential applied twice is approximately zero.
 
 ### Important Properties
 
-k-form → (k-1)-form
+$ \Omega_d^{k+1} (K) \rightarrow \Omega_d^k (K) $
 
-$ δf=0 $
+The discrete codifferential operator is a linear map that inputs discrete (k+1)-forms on mesh K and outputs discrete k-forms.
+
+$ δf = 0 $
+
 The formula above shows that the codifferential of a 0-form f is equal to zero. The codifferential operator takes a k-form and outputs a (k-1)-form. There is no such thing as a (-1)-form, so the operation outputs zero.
 
-$ δω=(−1)^{n(k−1)+1}⋆d⋆ω $
+$ δω = (−1)^{n(k−1)+1} ⋆ d ⋆ ω $
 
 The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  decides the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
 
-$ ⟨dω, β⟩=⟨ω, δβ⟩ $
+$ ⟨dω, β⟩ = ⟨ω, δβ⟩ $
 
 The exterior derivative and codifferential are adjoint in both the smooth and discrete settings. 
 
@@ -543,10 +561,10 @@ The exterior derivative and codifferential are adjoint in both the smooth and di
 Discrete Exterior Calculus - Hirani  
 Section 4.2 (p. 42)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 6 (p. 15)
 
-Discrete Differential Forms   
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.   
 Section 5.5
 
 ## Interior Product
@@ -555,11 +573,11 @@ Section 5.5
 
 Decapodes.jl
 
-    :i₁ => add_Inter_Prod_1D! or add_Inter_Prod_2D!(Val{1}, ...)  # Expands to ⋆⁻¹ → ∧ → ⋆
-    :i₂ => add_Inter_Prod_2D!(Val{2}, ...)                         # Same, no sign flip
+    :i₁ => add_Inter_Prod_1D! or add_Inter_Prod_2D!(Val{1}, ...)  
+    :i₂ => add_Inter_Prod_2D!(Val{2}, ...)                         
     
-    :ι₁₁ => interior_product_dd(Tuple{1,1}, sd)   # Dual-dual: ⋆₂ ∧₁₁ ⋆₁⁻¹
-    :ι₁₂ => interior_product_dd(Tuple{1,2}, sd)   # Dual-dual: ⋆₁ (♭♯ ∧₀₁ ⋆₀⁻¹)
+    :ι₁₁ => interior_product_dd(Tuple{1,1}, sd)   
+    :ι₁₂ => interior_product_dd(Tuple{1,2}, sd)   
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
 
@@ -585,7 +603,9 @@ Hirani notes the existence of an extrusion definition for this operator which is
 
 ### Important Properties
 
-k-form → (k-1)-form
+$ \Omega^k (M) \rightarrow \Omega^{k-1} (M) $
+
+The smooth interior product operator $ i_X $ maps k-forms on smooth manifold M to (k-1)-forms on M depending on vector field X. 
 
 $ i_X ω(X_1, …, X_k )=ω(X, X_1. …, X_k ) $
 
@@ -608,7 +628,7 @@ The interior product follows the Leibniz Rule. For non-closed forms, it is impor
 Discrete Exterior Calculus - Hirani  
 Section 8.2-8.3 (pp. 79-83)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 10 (pp. 24-26)
 
 ## Lie Derivative
@@ -617,11 +637,10 @@ Section 10 (pp. 24-26)
 
 Decapodes.jl
 
-    :L₀ => add_Lie_1D!(Val{0}, ...)  # d ∘ ι (interior then dual derivative)
-    :L₁ => add_Lie_1D!(Val{1}, ...)  # d ∘ ι (same in 1D)
-    :L₂ => add_Lie_2D!(Val{2}, ...)  # d ∘ ι (dual 2-form)
-    
-    :ℒ₁ => ℒ_dd(Tuple{1,1}, sd)      # Full dual-dual Lie: -(d∘ι + ι∘d)
+    :L₀ => add_Lie_1D!(Val{0}, ...)  
+    :L₁ => add_Lie_1D!(Val{1}, ...)  
+    :L₂ => add_Lie_2D!(Val{2}, ...)  
+    :ℒ₁ => ℒ_dd(Tuple{1,1}, sd)      
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
 
@@ -647,9 +666,11 @@ Hirani notes an alternative flow-out definition in Section 8.5 in his thesis, Di
 
 ### Important Properties
 
-k-form → k-form
+$ \Omega^k (M) \rightarrow \Omega^k (M) $
 
-$L_X ω=i_X (dω)+d(i_X ω)$
+The smooth lie derivative $ L_X $ maps k-forms on smooth manifold M to k-forms on M depending on vector field X.
+
+$ L_X ω = i_X (dω) + d(i_X ω) $
 
 This formula displays Cartan's Magic Formula, or an algebraic definition of the lie derivative using the interior product and the exterior derivative operators. This formula helps define the discrete primal-dual lie derivative operator on a simplicial complex. X is a discrete primal vector field and ω is a dual p-form.
 
@@ -663,23 +684,21 @@ This is the Leibniz Property of the lie derivative, which displays the lie deriv
 Discrete Exterior Calculus - Hirani  
 Section 8.4-8.5 (pp. 83-85)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 10 (pp. 25-26)
 
-## Laplace-Beltrami
+## Laplacian Operator
 
 ### Signature
 
 Decapodes.jl
 
-    :Δ₀ => add_De_Rham_1D!(Val{0}, ...)  # dδ + δd → expands to full Laplace–de Rham
+    :Δ₀ => add_De_Rham_1D!(Val{0}, ...)  
     :Δ₁ => add_De_Rham_1D!(Val{1}, ...) or add_De_Rham_2D!(Val{1}, ...)
     :Δ₂ => add_De_Rham_2D!(Val{2}, ...)
-    
-    :Δᵈ₀ => Δᵈ(Val{0}, sd)               # Dual 0-form Laplacian (fast version)
-    :Δᵈ₁ => Δᵈ(Val{1}, sd)               # Dual 1-form Laplacian
-    
-    :Δ₀⁻¹ => dec_inv_lap_solver(Val{0}, sd)  # factorize(∇²(0, sd)) \ x
+    :Δᵈ₀ => Δᵈ(Val{0}, sd)               
+    :Δᵈ₁ => Δᵈ(Val{1}, sd)              
+    :Δ₀⁻¹ => dec_inv_lap_solver(Val{0}, sd)  
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
 
@@ -687,7 +706,6 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     ∇²(n::Int, s::HasDeltaSet, args...; kw...)
     ∇²(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; kw...) where n
     ∇²(::Type{Val{n}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n
-    
     Δ(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
     Δ(n::Int, s::HasDeltaSet, args...; kw...)
     Δ(::Type{Val{0}}, s::HasDeltaSet, form::AbstractVector; kw...)
@@ -710,21 +728,23 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The Laplace-Beltrami operator generalizes the traditional Laplacian to curved surfaces. It linearly maps k-forms to k-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the functions surrounding it. A positive Laplacian implies that the point is less than the surrounding average (or convex down), while a negative one implies the point is greater than the surrounding average (or convex up).
+The Laplacian operator, or the Laplace-Beltrami operator on 0-forms, generalizes the traditional Laplacian onto curved surfaces. It linearly maps k-forms to k-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the functions surrounding it. A positive Laplacian implies that the point is less than the surrounding average (or convex down), while a negative one implies the point is greater than the surrounding average (or convex up).
 
-This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies to $δd$, as the exterior codifferential of a 0-form is always zero.
+This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies from $ \Delta = \delta d + d \delta $ to $ δd $, as the codifferential of a 0-form is always zero.
 
 It is represented as a sparse matrix. Due to its reliance on the codifferential (and thus the hodge star), it is metric-dependent. 
 
 ### Important Properties
 
-k-form → k-form
+$ \Omega^k (M) \rightarrow \Omega^k (M) $
 
-$Δ=dδ+δd$
+The smooth Laplace-deRham operator, the general form of the Laplace-Beltrami, maps k-forms on smooth manifold M to k-forms on the same manifold.
 
-This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $∇f=δdf$, is a special situation for 0-form functions, where $d(δf)=0$ as the codifferential of a 0-form is always zero.
+$ Δ = dδ + δd $
 
-$⟨Δf, σ^0 ⟩ =\frac{1}{ |\sigma_o| }  ∑_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
+This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $∇f=δdf$, is a special situation for 0-form functions, where $ d(δf) = 0$ as the codifferential of a 0-form is always zero.
+
+$ ⟨Δf, σ^0 ⟩ = \frac{1}{ |\sigma_o| }  ∑_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
 
 This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex $σ^0$,  $(⟨Δf, σ^0 ⟩)$ can be evaluated by the sum/contribution of all edges bordering $σ^0$, each weighted by the length of their corresponding dual edge divded by their primal length $(|⋆σ^1 |/|σ^1 | )$, and then multiplied by the difference between the form at the evaluated vertex $(f(σ^0))$ and the neighboring vertex $(f(v))$, connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell $(1/|⋆σ^0 | )$ to normalize it. This formula matches with another geometric Laplace-Beltrami formula that uses cotangents and indices.
 
@@ -733,5 +753,5 @@ This formula above showcases the evaluation of a 0-form (f) at a primal vertex (
 Discrete Exterior Calculus - Hirani  
 Section 6.4 (pp. 68-70)
 
-Discrete Exterior Calculus - Desbrun  
+Discrete Exterior Calculus - Desbrun et. al.  
 Section 10 (pp. 26-27)

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -136,7 +136,7 @@ $ d(ω∧β) = dω ∧ β + (−1)^{deg⁡(ω)} ω ∧ β $
 
 The formula above displays the Leibniz Principle of exterior derivatives. The operator has a product-rule-like relationship with the wedge product.
 
-$ d=∂^T $
+$ d = ∂^T $
 
 In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs k-forms and outputs the exterior derivative values of (k+1)-forms.
 

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -1,21 +1,12 @@
 # Discrete Exterior Calculus Operator Table
 
-This document is meant to provide simplified descriptions of the operators of Discrete Exterior Calculus. The reader can find more rigorous definitions in the referenced sources for each operator. The links to the sources referenced for the operators are below:
-
-[Discrete Exterior Calculus](https://www.cs.jhu.edu/~misha/Fall09/Hirani03.pdf) - Hirani
-
-
-[Discrete Exterior Calculus](https://arxiv.org/abs/math/0508341) - Desbrun et. al.
-
-[Notes on Discrete Exterior Calculus](https://math.arizona.edu/~agillette/research/decNotes.pdf) - Gillette
-
-[Discrete Differential Forms for Computational Modeling](https://geometry.caltech.edu/pubs/DKT05.pdf) - Desbrun et. al.  
+This document is meant to provide simplified descriptions of the operators of discrete exterior calculus (DEC). The reader can find more rigorous definitions in the referenced sources for each operator. The links to the sources referenced for the operators are at the bottom of the document.
 
 ## Boundary
 
 ### Signature
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ∂(s::HasDeltaSet, x::DualChain{n}) where n
     dual_boundary(n::Int, s::HasDeltaSet, args...)
@@ -23,9 +14,6 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, x::Int)
     dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int)
     dual_boundary_nz(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, x::Int)
-
-CombinatorialSpaces.jl, FastDEC.jl
-
     dec_boundary(n::Int, sd::HasDeltaSet)
     dec_p_boundary(::Type{Val{k}}, sd::HasDeltaSet; negate::Bool=false) where {k}
 
@@ -35,7 +23,7 @@ The boundary operator acts on the geometry of the mesh, linearly mapping k-chain
 
 This operator inputs k-chains and outputs (k-1)-chains (or k-manifolds to (k-1)-manifolds in the smooth case). For example, it could map a 1-chain, representing a line, to the two endpoints of that line. This operator has nilpotency, meaning the boundary operator applied to the same geometry is always zero. This property is important in the exterior derivative for preserving geometric invariants and physical conservation laws. 
 
-This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_{k−1} |×|C_k |$. It inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. The computation of this operator is local, topological, and coordinate-free. As the geometric intuition for this matrix calculation is difficult to describe, I recommend further investigation online.
+This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_{k−1} |×|C_k |$. It inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. The computation of this operator is local, topological, and coordinate-free.
 
 This tool is important in defining the exterior derivative operator through Generalized Stokes' Theorem. This theorem states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. Using this definition and the boundary operator's duality, the exterior derivative is the transpose of the boundary matrix. 
 
@@ -77,7 +65,7 @@ Section 3
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
     
     :d₀ => dec_differential(0, sd) |> matmul
     :d₁ => dec_differential(1, sd) |> matmul
@@ -86,14 +74,11 @@ Decapodes.jl
     :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
     :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     d(s::HasDeltaSet, x::DualForm{n}) where n
     dual_derivative(n::Int, s::HasDeltaSet, args...) dual_derivative(::Type{Val{n}}, s::HasDeltaSet, args...) where n
     dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex1D, x::Int) dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, x::Int) dual_derivative_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int)
-
-CombinatorialSpaces.jl, FastDEC.jl
-
     dec_differential(n::Int, sd::HasDeltaSet)
     dec_dual_derivative(n::Int, sd::HasDeltaSet)
     dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet1D)
@@ -108,9 +93,9 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The exterior derivative operator (ED) extends the idea of differentiation into differential geometry. It generalizes vector calculus concepts such as gradient, divergence, and curl onto multidimensional forms. It is a requirement for modelling any partial differential equation in an exterior calculus framework.
+The exterior derivative operator extends the idea of differentiation into differential geometry. It generalizes vector calculus concepts such as gradient, divergence, and curl onto multidimensional forms. It is a requirement for modeling any partial differential equation in an exterior calculus framework.
 
-This operator linearly maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the ED operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. The ED on a 3-form in 3D space is always zero.
+This operator linearly maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the exterior derivative operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. This operator on a 3-form in 3D space is always zero.
 
 This operator matrix is calculated with Generalized Stokes' Theorem, which states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. In the discrete setting, the exterior derivative for a cochain is the transpose of the boundary matrix operator for its respective chain. Like the boundary operator, it is a sparse matrix with elements 0, +1, and -1. The computation of this operator is local, topological, and coordinate-free.
 
@@ -134,7 +119,7 @@ The exterior derivative applied twice to the same form is always zero. This prop
 
 $ d(ω∧β) = dω ∧ β + (−1)^{deg⁡(ω)} ω ∧ β $
 
-The formula above displays the Leibniz Principle of exterior derivatives. The operator has a product-rule-like relationship with the wedge product.
+The formula above displays the Leibniz Product Rule of exterior derivatives. The operator has a product-rule-like relationship with the wedge product.
 
 $ d = ∂^T $
 
@@ -166,7 +151,7 @@ Section 4.1-4.3
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)  
     :∧₁₀ => dec_pair_wedge_product(Tuple{1,0}, sd)
@@ -181,7 +166,7 @@ Decapodes.jl
     :∧ᵈᵈ₁₀ => dec_wedge_product_dd(Tuple{1,0}, sd)
     :∧ᵈᵈ₀₁ => dec_wedge_product_dd(Tuple{0,1}, sd)
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ∧(s::HasDeltaSet, α::SimplexForm{k}, β::SimplexForm{l}) where {k,l}
     ∧(k::Int, l::Int, s::HasDeltaSet, args...)
@@ -193,9 +178,6 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     ∧(::Type{Tuple{2,1}}, s::HasDeltaSet3D, α, β, x::Int)
     ∧(::Type{Tuple{1,2}}, s::HasDeltaSet3D, α, β, x::Int)
     wedge_product_zero(::Type{Val{k}}, s::HasDeltaSet, f, α, x::Int) where k
-
-CombinatorialSpaces.jl, FastDEC.jl
-
     ∧(s::HasDeltaSet, α::SimplexForm{k}, β::SimplexForm{l}) where {k,l}
     ∧(s::HasDeltaSet, α::SimplexForm{1}, β::DualForm{1})
     ∧(s::HasDeltaSet, α::DualForm{1}, β::SimplexForm{1})
@@ -223,11 +205,11 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 The wedge product operator is used to "combine" a k-form and an l-form into a higher degree (k+l)-form. As an example, imagine two vector-like 1-cochains. The wedge product would be the signed area formed by dragging one of the forms across the other, like a determinant.
 
-It is an anti-commutative operator, meaning $β∧ω$ is often equal to $−ω∧β$ under most circumstances. It is also associative, meaning $(ω∧β)∧γ=ω∧(β∧γ)$. In the discrete case however, the associative property is limited to only closed forms. The exterior derivative of closed forms is always zero. Later operators which use this tool as a component also face this limitation.
+This operator is commutative when when either k or l are even, meaning $ \beta \wedge \omega = \omega \wedge \beta $. However, if both forms have odd degrees, then the operator is anti-commutative, meaning  $ β ∧ ω = − ω ∧ β $. It is also associative, where $ ( ω ∧ β) ∧ γ =ω ∧ ( β ∧ γ ) $. In the discrete case however, the associative property is limited to only closed forms. A closed form is a form whose exterior derivative is zero. Later operators which use this tool as a component also face this limitation.
 
 Another limitation is the wedge product's reliance on the metric. Certain operator formulas may require defined angles for calculating the result of this operator. However, other formulas may lack this limitation. Formulas that are not metric-dependent are natural with respect to discrete pullbacks.
 
-Finally, the Leibniz Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas shown below. 
+Finally, the Leibniz Product Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas shown below. 
 
 ### Important Properties
 
@@ -255,9 +237,9 @@ $
 
 The formula above is the topological primal-primal wedge product operator. It follows the same trend as the metric case. However, this one does not use a geometric weighing factor, and instead accounts for weight with normalization $(1/(k+l+1)!)$. 
 
-$ ω∧β=(−1)^{deg⁡(ω)deg⁡(β)}⁡(β∧ω) $
+$ ω^k ∧ β^l =(−1) ^ {kl}⁡(β∧ω) $
 
-This formula displays the anti-commutative property of wedge product. Switching the order of the forms on the wedge product may swap the sign of the resulting higher degree form. This is the extension of the idea that forms are antisymmetric tensors, and swapping the forms that create a higher form change the orientation of the area/volume/length.
+This formula displays the commutative (or anti-commutative) property of wedge product. If the inputted form degrees (k and l) are both odd, switching the order of the forms on the wedge product would swap the sign of the outputted form. This is the extension of the idea that forms are antisymmetric tensors, and swapping the forms that create a higher degree form change the orientation of the area/volume/length. However, if either l or l are even, then swapping terms in the wedge product will not affect signage.
 
 $ (ω∧β)∧γ = ω∧(β∧γ) $
 
@@ -265,7 +247,7 @@ This formula displays the associative property of the wedge product operator in 
 
 $ d(ω∧β) = dω ∧ β+(−1)^{deg⁡(ω)} ω ∧ β $
 
-As displayed in the exterior derivative section, the Leibniz Rule defines the interaction between the exterior derivative and the wedge product operators. 
+As displayed in the exterior derivative section, the Leibniz Product Rule defines the interaction between the exterior derivative and the wedge product operators. 
 
 $ ω ∧ ω = 0 $
 
@@ -283,7 +265,7 @@ Section 8 (pp. 17-21)
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :⋆₀ => dec_hodge_star(0, sd, hodge=hodge) |> matmul
     :⋆₁ => dec_hodge_star(1, sd, hodge=hodge) |> matmul
@@ -292,7 +274,7 @@ Decapodes.jl
     :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge)  
     :⋆₂⁻¹ => dec_inv_hodge_star(1, sd, hodge) |> matmul
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ⋆(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
     ⋆(n::Int, s::HasDeltaSet, args...; kw...)
@@ -321,9 +303,6 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     inv_hodge_star(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
     inv_hodge_star(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, ::GeometricHodge) where n
     inv_hodge_star(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, form::AbstractVector, ::GeometricHodge) where n
-    
-CombinatorialSpaces.jl, FastDEC.jl
-
     dec_hodge_star(n::Int, sd::HasDeltaSet; hodge=GeometricHodge())
     dec_hodge_star(n::Int, sd::HasDeltaSet, ::DiagonalHodge)
     dec_hodge_star(n::Int, sd::HasDeltaSet, ::GeometricHodge)
@@ -353,13 +332,13 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The hodge star operator maps k-forms to their respective "orthogonal" (n-k)-forms based on the Riemannian metric (or inner product). 'n' is the number of dimensions in the space. It relates the primal mesh to the dual mesh. For example, in 2D space, points are outputted as areas, lines become orthogonal lines, and areas become midpoints of the space. It is also an important component in later operators.
+The Hodge star operator maps k-forms to their respective "orthogonal" (n-k)-forms based on the Riemannian metric (or inner product). 'n' is the number of dimensions in the space. It relates the primal mesh to the dual mesh. For example, in 2D space, points are outputted as areas, lines become orthogonal lines, and areas become midpoints of the space. It is also an important component in later operators.
 
-The discrete hodge star is computed using a formula which states that the original form evaluated on the original simplex divided by the simplex's magnitude is equivalent to the starred form evaluated on the "orthogonal" simplex divided by the "orthogonal" simplex's magnitude. This formula ensures dual and primal meshes contain the same information. The operator is also an isomorphism, meaning the hodge star applied twice to a form will return the original form (with a potential sign change depending on dimensions). 
+The discrete Hodge star is computed using a formula which states that the original form evaluated on the original simplex divided by the simplex's magnitude is equivalent to the starred form evaluated on the "orthogonal" simplex divided by the "orthogonal" simplex's magnitude. This formula ensures dual and primal meshes contain the same information. The operator is also an isomorphism, meaning the Hodge star applied twice to a form will return the original form (with a potential sign change depending on dimensions). 
 
-The operator matrix is calculated through either two methods - the geometric hodge or the diagonal hodge. The geometric hodge is calculated as a sparse, symmetrical matrix with elements dependent on the ratio between simplex and orthogonal simplex magnitudes. It pairs well with barycentric dual mesh centering. The matrix dimensions are $|C_k |×|C_k |$. The diagonal hodge is a diagonal matrix with the same dimensions. It is calculated faster but has less accuracy. It pairs well with circumcentric dual mesh centering.
+The operator matrix is calculated through either two methods - the geometric Hodge or the diagonal Hodge. The geometric Hodge is calculated as a sparse, symmetrical matrix with elements dependent on the ratio between simplex and orthogonal simplex magnitudes. It pairs well with barycentric dual mesh centering. The matrix dimensions are $|C_k |×|C_k |$. The diagonal Hodge is a diagonal matrix with the same dimensions. It is calculated faster but has less accuracy. It pairs well with circumcentric dual mesh centering.
 
-This operator is metric-dependent. It is reliant on a metric to determine angles and orthogonality. Thus, the result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on if the dual mesh is barycentric-centered or circumcentric-centered, the hodge star may return differing results. Furthermore, stretching the mesh would cause changes in simplex magnitudes on primal and dual meshes, thus affecting the output values from the hodge star operator.
+This operator is metric-dependent. It is reliant on a metric to determine angles and orthogonality. Thus, the result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on if the dual mesh is barycentric-centered or circumcentric-centered, the Hodge star may return differing results. Furthermore, stretching the mesh would cause changes in simplex magnitudes on primal and dual meshes, thus affecting the output values from the Hodge star operator.
 
 Finally, as this operator is metric-dependent, it does not commute fully with respect to natural pullbacks. However, the code attempts to approximate this property as much as possible for accurate simulations.
 
@@ -367,11 +346,11 @@ Finally, as this operator is metric-dependent, it does not commute fully with re
 
 $ *^k:\Omega^k\_d (K) \rightarrow \Omega^{n - k}\_d (\star K) $
 
-The discrete hodge star linearly maps discrete k-forms on mesh K to discrete (n-k)-forms on dual mesh $ \star K$, where n is the number of dimensions of the space. The $ \star $ symbol acts on geometry and outputs its dual version.
+The discrete Hodge star linearly maps discrete k-forms on mesh K to discrete (n-k)-forms on dual mesh $ \star K$, where n is the number of dimensions of the space. The $ \star $ symbol acts on geometry and outputs its dual version.
 
 $ ⟨ω^k, β^k ⟩v = ω^k∧*β^k $
 
-The formula above displays the identity of the hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the right-hand side. Due to this definition, it is inherently a metric-dependent operator.
+The formula above displays the identity of the Hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the Hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the right-hand side. Due to this definition, it is inherently a metric-dependent operator.
 
 $ 
 \frac{1}{|⋆σ^k |}  
@@ -379,11 +358,11 @@ $
 \frac{1}{|σ^k |}  ⟨ω, σ^k ⟩
 $
 
-The formula above is the definition of the discrete hodge star for $1≤k≤n−1$ forms. It states that the hodge star of a form integrated on the dual of a simplex and divided by the length of that dual simplex must be equal to the form evaluated on the primal simplex, divided by the length of that primal simplex. The dual form maintains the same physical information while transitioning to orthogonality. Forms that do not conform to the inequality have an additional term that changes sign to account for simplex orientation.
+The formula above is the definition of the diagonal Hodge star for $1≤k≤n−1$ forms. It states that the Hodge star of a form integrated on the dual of a simplex and divided by the length of that dual simplex must be equal to the form evaluated on the primal simplex, divided by the length of that primal simplex. The dual form maintains the same physical information while transitioning to orthogonality. Forms that do not conform to the inequality have an additional term that changes sign to account for simplex orientation.
 
 $ **ω = (−1)^k (n−k)ω $
 
-The hodge star operator is an isomorphism. Using the hodge star on a form twice returns it to its original state, with a change in sign depending on dual orientation.
+The Hodge star operator is an isomorphism. Using the Hodge star on a form twice returns it to its original state, with a change in sign depending on dual orientation.
 
 ### Citations
 
@@ -403,13 +382,12 @@ Section 5.3-5.4
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :♭ᵈᵖ => dec_♭(sd)                    
     :♭♯ => ♭♯_mat(sd) |> matmul          
 
-
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ♭(s::HasDeltaSet, X::DualVectorField)
     ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::DPPFlat)
@@ -457,13 +435,13 @@ Section 2.12 (pp. 14-15)
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :♯ᵖᵈ => dec_♯_pd(sd)                 
     :♯ᵖᵖ => dec_♯_pp(sd)                 
     :♯ᵈᵈ => dec_♯_dd(sd)                 
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ♯(s::HasDeltaSet2D, α::EForm)
     ♯(s::HasDeltaSet2D, α::DualForm{1})
@@ -509,12 +487,12 @@ Section 7 (p. 16)
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :δ₁ => add_Codiff!(d, src, tgt)  
     :δ₂ => add_Codiff!(d, src, tgt)
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     δ(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
     δ(n::Int, s::HasDeltaSet, args...; kw...)
@@ -528,9 +506,9 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
 
 The codifferential operator acts as the adjoint of the exterior derivative. It linearly maps k-forms to (k-1)-forms. This operator can represent divergence and it is used in the algebraic definition of the Laplacian operator.
 
-This operator is metric due to the reliance of the hodge star in its definition. It is represented as a sparse matrix created by combining hodge star and exterior derivative matrices. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation.
+This operator is metric due to the reliance of the Hodge star in its definition. It is represented as a sparse matrix created by combining Hodge star and exterior derivative matrices. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation.
 
-Finally, due to the presence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. However, due to inaccuracies in the discrete hodge star, the discrete codifferential applied twice is only approximately zero.
+Finally, due to the presence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. However, due to inaccuracies in the discrete Hodge star, the discrete codifferential applied twice is only approximately zero.
 
 ### Important Properties
 
@@ -544,7 +522,7 @@ The formula above shows that the codifferential of a 0-form f is equal to zero. 
 
 $ δω = (−1)^{n(k−1)+1} * d * ω $
 
-The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  represents the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
+The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through Hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  represents the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
 
 $ ⟨dω, β⟩ = ⟨ω, δβ⟩ $
 
@@ -565,7 +543,7 @@ Section 5.5
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :i₁ => add_Inter_Prod_1D! or add_Inter_Prod_2D!(Val{1}, ...)  
     :i₂ => add_Inter_Prod_2D!(Val{2}, ...)                         
@@ -573,14 +551,11 @@ Decapodes.jl
     :ι₁₁ => interior_product_dd(Tuple{1,1}, sd)   
     :ι₁₂ => interior_product_dd(Tuple{1,2}, sd)   
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     interior_product(s::HasDeltaSet, X♭::EForm, α::DualForm{n}; kw...) where n
     interior_product_flat(n::Int, s::HasDeltaSet, args...; kw...)
     interior_product_flat(::Type{Val{n}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...) where n
-
-CombinatorialSpaces.jl, FastDEC.jl
-
     interior_product_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
     interior_product_dd(::Type{Tuple{1,2}}, s::SimplicialSets.HasDeltaSet)
 
@@ -589,9 +564,9 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 The interior product contracts a vector field with a k-form, outputting a (k-1)-form. It is an operator that "combines" forms and vector fields together by plugging in the field into one of the form's inputs. In exterior algebra, forms are measurement tools that input vectors and output scalar values. The interior product makes use of this definition to merge vector fields and forms together.
 
-In the smooth setting, it is a topological operator. However, using the algebraic definition, this tool becomes metric due to its reliance on the flat and hodge star operators.
+In the smooth setting, it is a topological operator. However, using the algebraic definition, this tool becomes metric due to its reliance on the flat and Hodge star operators.
 
-Due to the use of the wedge product in its definition, the Leibniz Property for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie derivative, which faces this limitation as well. 
+Due to the use of the wedge product in its definition, the Leibniz Product Rule for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie derivative, which faces this limitation as well. 
 
 Hirani notes the existence of an extrusion definition for this operator which is not covered in this description. However, it should be known that algebraic contraction is dual to the idea of extrusion in a geometric setting.
 
@@ -605,9 +580,9 @@ $ i\_X ω(X\_1, …, X\_k ) = ω(X, X\_1. …, X\_k ) $
 
 The above definition shows the algebraic definition of the interior product. This operator contracts a vector field with a k-form, "inserting" itself into one of the slots of the form. The output is a (k-1)-form.
 
-$ i_X ω = (−1)^k(n−k) *(*ω∧X^♭ ) $
+$ i\_X \omega = (-1)^{k(n-k)} * ( * \omega \wedge X^\flat ) $
 
-The above identity displays the definition of the interior product operator composed of hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The wedge product, hodge star, and flat operations $(*ω∧X^{\flat})$ represents inserting the contribution of vector field X into the form ω. The exterior hodge star returns the result to its proper dimension, k+1. Finally, the $(−1)^k(n−k)$ accounts for changes in orientation due to the hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Property for contraction will only apply to closed forms (where $dω=0$), as the discrete wedge product is only associative on closed forms.
+The above identity displays the definition of the interior product operator composed of Hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The wedge product, Hodge star, and flat operations $(*ω∧X^{\flat})$ represents inserting the contribution of vector field X into the form ω. The exterior Hodge star returns the result to its proper dimension, k+1. Finally, the $(−1)^k(n−k)$ accounts for changes in orientation due to the Hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Product Rule for contraction will only apply to closed forms (where $dω=0$), as the discrete wedge product is only associative on closed forms.
 
 $ i_X (f) = 0 $
 
@@ -615,7 +590,7 @@ The interior product of a 0-form f with a vector field X is always zero.
 
 $ i\_X (ω^k ∧ β^l ) = (i\_X ω)∧β+(−1)^k ω∧(i\_X β) $
 
-The interior product operator follows the Leibniz Rule. For non-closed forms, it is important to note that the discrete wedge product is not associative and thus errors in this rule may appear.
+The interior product operator follows the Leibniz Product Rule. For non-closed forms, it is important to note that the discrete wedge product is not associative and thus errors in this rule may appear.
 
 ### Citations
 
@@ -629,23 +604,20 @@ Section 10 (pp. 24-26)
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :L₀ => add_Lie_1D!(Val{0}, ...)  
     :L₁ => add_Lie_1D!(Val{1}, ...)  
     :L₂ => add_Lie_2D!(Val{2}, ...)  
     :ℒ₁ => ℒ_dd(Tuple{1,1}, sd)      
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ℒ(s::HasDeltaSet, X♭::EForm, α::DualForm{n}; kw...) where n
     lie_derivative_flat(n::Int, s::HasDeltaSet, args...; kw...)
     lie_derivative_flat(::Type{Val{0}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...)
     lie_derivative_flat(::Type{Val{1}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...)
     lie_derivative_flat(::Type{Val{2}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...)
-
-CombinatorialSpaces.jl, FastDEC.jl
-
     ℒ_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
 
 ### Description
@@ -654,7 +626,7 @@ The Lie Derivative operator inputs a k-form and outputs a k-form representing th
 
 The Lie derivative's algebraic definition is displayed in Cartan's Magic Formula, which uses exterior derivative and interior product operators. This smooth formula is used to define the discrete primal-dual lie derivative, where X is a discrete vector field on the primal mesh and ω is a dual k-form.
 
-However, this method may not satisfy the Leibniz Property of Lie Derivatives, as it uses the discrete wedge product operator (within the interior product operator). This operator is only associative on closed forms. 
+However, this method may not satisfy the Leibniz Product Rule of Lie Derivatives, as it uses the discrete wedge product operator (within the interior product operator). This operator is only associative on closed forms. 
 
 Hirani notes an alternative flow-out definition in Section 8.5 in his thesis, Discrete Exterior Calculus, which does not suffer from this lack of associativity. However, this definition is not covered here.
 
@@ -671,7 +643,7 @@ This formula displays Cartan's Magic Formula, or an algebraic definition of the 
 
 $ \mathcal{L}\_X (ω ∧ β) = \mathcal{L}\_X (ω) ∧ β + ω ∧ \mathcal{L}\_X (β) $
 
-This is the Leibniz Property of the Lie derivative, which displays the Lie derivative's relationship with wedge product in the smooth case. In the discrete case, if the algebraic definition of the interior product is used, this relationship might not always be correct. This is because the algebraic interior product is defined using the wedge product. As the wedge product is only associative on closed forms (in the discrete setting), there may be errors in this Leibniz property.
+This is the Leibniz Product Rule of the Lie derivative, which displays the Lie derivative's relationship with wedge product in the smooth case. In the discrete case, if the algebraic definition of the interior product is used, this relationship might not always be correct. This is because the algebraic interior product is defined using the wedge product. As the wedge product is only associative on closed forms (in the discrete setting), there may be errors in this property.
 
 ### Citations
 
@@ -685,7 +657,7 @@ Section 10 (pp. 25-26)
 
 ### Signature
 
-Decapodes.jl
+#### Decapodes.jl
 
     :Δ₀ => add_De_Rham_1D!(Val{0}, ...)  
     :Δ₁ => add_De_Rham_1D!(Val{1}, ...) or add_De_Rham_2D!(Val{1}, ...)
@@ -694,7 +666,7 @@ Decapodes.jl
     :Δᵈ₁ => Δᵈ(Val{1}, sd)              
     :Δ₀⁻¹ => dec_inv_lap_solver(Val{0}, sd)  
 
-CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+#### CombinatorialSpaces.jl
 
     ∇²(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
     ∇²(n::Int, s::HasDeltaSet, args...; kw...)
@@ -710,9 +682,6 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...)
     Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector; kw...)
     Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...)
-    
-CombinatorialSpaces.jl, FastDEC.jl
-
     Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet)
     Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet2D)
     Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet3D)
@@ -726,7 +695,7 @@ The Laplacian operator, or the Laplace-Beltrami operator on 0-forms, generalizes
 
 This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies from $ \Delta = \delta d + d \delta $ to $ δd $, as the codifferential of a 0-form is always zero.
 
-It is represented as a sparse matrix. Due to its reliance on the codifferential (and thus the hodge star), it is metric-dependent. 
+It is represented as a sparse matrix. Due to its reliance on the codifferential (and thus the Hodge star), it is metric-dependent. 
 
 ### Important Properties
 
@@ -736,7 +705,7 @@ The discrete Laplace-deRham operator, the general form of the Laplace-Beltrami, 
 
 $ Δ = dδ + δd $
 
-This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $ \Delta f=δdf $, is a special situation for 0-form functions where $ d(δf) = 0$ as the codifferential of a 0-form is always zero.
+This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $ \Delta f=δdf $, is a special situation for 0-forms where $ d(δf) = 0 $, as the codifferential of a 0-form is always zero.
 
 $ ⟨Δf, σ^0 ⟩ = \frac{1}{ |\sigma\_o| }  ∑\_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
 
@@ -749,3 +718,13 @@ Section 6.4 (pp. 68-70)
 
 Discrete Exterior Calculus - Desbrun et. al.\
 Section 10 (pp. 26-27)
+
+## References
+
+[Discrete Exterior Calculus](https://www.cs.jhu.edu/~misha/Fall09/Hirani03.pdf) - Hirani
+
+[Discrete Exterior Calculus](https://arxiv.org/abs/math/0508341) - Desbrun et. al.
+
+[Notes on Discrete Exterior Calculus](https://math.arizona.edu/~agillette/research/decNotes.pdf) - Gillette
+
+[Discrete Differential Forms for Computational Modeling](https://geometry.caltech.edu/pubs/DKT05.pdf) - Desbrun et. al.  

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -155,24 +155,236 @@ Section 4.1-4.3
 
 ### Signature
 
+Decapodes.jl
+
+    :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)  # Returns (in-place kernel, out-of-place)
+    :∧₁₀ => dec_pair_wedge_product(Tuple{1,0}, sd)
+    :∧₀₂ => dec_pair_wedge_product(Tuple{0,2}, sd)
+    :∧₂₀ => dec_pair_wedge_product(Tuple{2,0}, sd)
+    :∧₁₁ => dec_pair_wedge_product(Tuple{1,1}, sd)
+    
+    :∧ᵖᵈ₁₁ => dec_wedge_product_pd(Tuple{1,1}, sd)
+    :∧ᵖᵈ₀₁ => dec_wedge_product_pd(Tuple{0,1}, sd)
+    :∧ᵈᵖ₁₁ => dec_wedge_product_dp(Tuple{1,1}, sd)
+    :∧ᵈᵖ₁₀ => dec_wedge_product_dp(Tuple{1,0}, sd)
+    
+    :∧ᵈᵈ₁₁ => dec_wedge_product_dd(Tuple{1,1}, sd)
+    :∧ᵈᵈ₁₀ => dec_wedge_product_dd(Tuple{1,0}, sd)
+    :∧ᵈᵈ₀₁ => dec_wedge_product_dd(Tuple{0,1}, sd)
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ∧(s::HasDeltaSet, α::SimplexForm{k}, β::SimplexForm{l}) where {k,l}
+    ∧(k::Int, l::Int, s::HasDeltaSet, args...)
+    ∧(::Type{Tuple{k,l}}, s::HasDeltaSet, α, β) where {k,l}
+    ∧(::Type{Tuple{0,0}}, s::HasDeltaSet, f, g, x::Int)
+    ∧(::Type{Tuple{k,0}}, s::HasDeltaSet, α, g, x::Int) where k
+    ∧(::Type{Tuple{0,k}}, s::HasDeltaSet, f, β, x::Int) where k
+    ∧(::Type{Tuple{1,1}}, s::HasDeltaSet2D, α, β, x::Int)
+    ∧(::Type{Tuple{2,1}}, s::HasDeltaSet3D, α, β, x::Int)
+    ∧(::Type{Tuple{1,2}}, s::HasDeltaSet3D, α, β, x::Int)
+    wedge_product_zero(::Type{Val{k}}, s::HasDeltaSet, f, α, x::Int) where k
+
+CombinatorialSpaces.jl, FastDEC.jl
+
+    ∧(s::HasDeltaSet, α::SimplexForm{k}, β::SimplexForm{l}) where {k,l}
+    ∧(s::HasDeltaSet, α::SimplexForm{1}, β::DualForm{1})
+    ∧(s::HasDeltaSet, α::DualForm{1}, β::SimplexForm{1})
+    dec_wedge_product(::Type{Tuple{m,n}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
+    dec_wedge_product(m::Int, n::Int, sd::HasDeltaSet)
+    dec_wedge_product(::Type{Tuple{0,0}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+    dec_wedge_product(::Type{Tuple{k,0}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
+    dec_wedge_product(::Type{Tuple{0,k}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
+    dec_wedge_product(::Type{Tuple{1,1}}, sd::HasDeltaSet2D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+    dec_wedge_product(::Type{Tuple{1,2}}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+    dec_wedge_product(::Type{Tuple{2,1}}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+    dec_wedge_product_dd(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+    dec_wedge_product_dd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
+    dec_wedge_product_dd(::Type{Tuple{1,0}}, sd::HasDeltaSet)
+    dec_wedge_product_dp(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+    dec_wedge_product_dp(::Type{Tuple{1,0}}, sd::HasDeltaSet)
+    dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
+    dec_wedge_product_pd(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+    dec_wedge_product_pd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
+    dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
+    dec_c_wedge_product!(::Type{Tuple{j,k}}, res, α, β, p, c) where {j,k}
+    dec_c_wedge_product(::Type{Tuple{m,n}}, α, β, wedge_cache) where {m,n}
+
 ### Description
+
+The wedge product operator is used to "combine" a k-form and an l-form into a higher degree (k+l)-form. As an example, imagine two vector-like 1-cochains. The wedge product would be the signed area formed by dragging one of the forms across the other, like a determinant. For this reason, the wedge product has nilpotency, where the wedge product of the same form $(ω∧ω=0)$ is likely zero.
+
+It is an anticommutative operator, meaning $β∧ω$ is often equal to $−ω∧β$ under most circumstances. It is also associative, meaning $(ω∧β)∧γ=ω∧(β∧γ)$. In the discrete case however, the associative property is limitted to only closed forms. The exterior derivative of closed forms is always zero. Later operators which use this tool as a component also face this limitation.
+
+Another limitation is the wedge product's reliance on the metric. Certain operator formulas may require defined angles for calculating the result of this operator. However, other formulas may lack this limitation. Formulas that are not metric-dependent are natural with respect to discrete pullbacks.
+
+Finally, the Leibniz Rule displays an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas. 
 
 ### Important Properties
 
+$ deg⁡(ω)+deg⁡(β)=deg⁡(ω∧β) $
+
+The wedge product combines a k-form and a p-form and creates a (k+p)-form.
+
+
+$ 
+\langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
+\frac{1}{(k+l)!} 
+\sum_{r\in S_{k+l+1}} sign(\tau) \frac{|\sigma^{k+l} \cap \star v_{\tau(k)}|}{|\sigma^{k+l}|} 
+\langle \omega, [v_{\tau(0)}, ..., v_{\tau(k)}] \rangle 
+\langle \beta, [v_{\tau(k)}, ..., v_{\tau(k+l)}] \rangle 
+$
+
+This is the metric formulation for the discrete primal-primal wedge product operator, where ω is a is a discrete primal k-form and β is a discrete primal l-form. The LHS states that the evaluation of the wedge product of two forms on the appropraite face is equal to the RHS. The RHS states that for each permutation of the simplex $σ^{k+l}$  (where there are $(k+l+1)!$  orderings of the vertices), it finds the sign of that permutation $(sign(τ))$ and multiplies it by a geometric weight $(|σ^{k+l}∩⋆v_τ (k)| / |σ^(k+l) | )$. The weight determines the volume of the new simplex that is shared by the simplices touching the k-th vertex of the current permutation, divided by the volume of the new simplex. Finally, it multiplies this weight by the inner product of ω on a k-simplex formed from initial vertices $(⟨ω, [v_τ(0) , …, v_τ(k) ]⟩)$ and the inner product of β on a l-simplex formed from the vertices afterwards $(⟨β, [v_τ(k) , …, v_τ(k+l) ]⟩)$. The contributions from each permutation are summed together and normalized based on the forms' dimensions $(1/(k+l)!)$. As this formula relies on simplex magnitudes, it is metric.
+
+$ 
+\langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
+\frac{1}{(k+l+1)!} 
+\sum_{r\in S_{k+l+1}} sign(\tau)  
+\langle \omega, [v_{\tau(0)}, ..., v_{\tau(k)}] \rangle 
+\langle \beta, [v_{\tau(k)}, ..., v_{\tau(k+l)}] \rangle 
+$
+
+The formula above is the topological primal-primal wedge product operator. It follows the same trend as the metric case. However, this one does not use a geometric weighing factor, and instead accounts for weight with normalization $(1/(k+l+1)!)$. 
+
+$ ω∧β=(−1)^{deg⁡(ω)deg⁡(β)}⁡(β∧ω) $
+
+This formula displays the anti-commutative property of wedge product. Switching the order of the forms on the wedge product may swap the sign of the resulting higher degree form. This is the extension of the idea that forms are antisymmetric tensors, and swapping the forms that create a higher form change the orientation of the area/volume/length.
+
+$ (ω∧β)∧γ=ω∧(β∧γ) $
+
+This formula displays the associative property of the wedge product operator in the smooth case. In the discrete case, this is only true for closed forms. The exterior derivative of a closed form is zero.
+
+$ ω∧ω=0 $
+
+This formula shows the nilpotency property of wedge product in the smooth case. Consider two differing 1-forms, ω and β, which can be considered dual to vectors. Then, think of the wedge product as an operator which finds the signed area of the parallelogram created by smearing one of those vectors across the edge of the other. If those two forms were in the same direction, like two ω forms, the smearing would only create a line with an area of zero.
+
 ### Citations
 
+Discrete Exterior Calculus - Hirani  
+Section 7.1-7.3 (pp. 71-76)
+
+Discrete Exterior Calculus - Desbrun  
+Section 8 (pp. 17-21)
 
 ## Hodge Star
 
 ### Signature
 
+Decapodes.jl
+
+    :⋆₀ => dec_hodge_star(0, sd, hodge=hodge) |> matmul
+    :⋆₁ => dec_hodge_star(1, sd, hodge=hodge) |> matmul
+    :⋆₂ => dec_hodge_star(2, sd, hodge=hodge) |> matmul
+    
+    :⋆₀⁻¹ => dec_inv_hodge_star(0, sd, hodge) |> matmul
+    :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge)  # Special: returns (in-place, out-of-place) solver
+    :⋆₂⁻¹ => dec_inv_hodge_star(1, sd, hodge) |> matmul
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ⋆(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
+    ⋆(n::Int, s::HasDeltaSet, args...; kw...)
+    ⋆(::Type{Val{n}}, s::HasDeltaSet; hodge::DiscreteHodge=GeometricHodge()) where n
+    ⋆(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; hodge::DiscreteHodge=GeometricHodge()) where n
+    ⋆(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector, ::DiagonalHodge) where n
+    ⋆(::Type{Val{n}}, s::HasDeltaSet, ::DiagonalHodge) where n
+    ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+    ⋆(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+    ⋆(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+    ⋆(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
+    ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
+    ⋆(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
+    ⋆(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, ::GeometricHodge) where n
+    ⋆(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, form::AbstractVector, ::GeometricHodge) where n
+    inv_hodge_star(n::Int, s::HasDeltaSet, args...; kw...)
+    inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet; hodge::DiscreteHodge=GeometricHodge()) where n
+    inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; hodge::DiscreteHodge=GeometricHodge()) where n
+    inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector, ::DiagonalHodge) where n
+    inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet, ::DiagonalHodge) where n
+    inv_hodge_star(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+    inv_hodge_star(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
+    inv_hodge_star(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+    inv_hodge_star(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+    inv_hodge_star(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
+    inv_hodge_star(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge)
+    inv_hodge_star(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, ::GeometricHodge) where n
+    inv_hodge_star(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, form::AbstractVector, ::GeometricHodge) where n
+    
+CombinatorialSpaces.jl, FastDEC.jl
+
+    dec_hodge_star(n::Int, sd::HasDeltaSet; hodge=GeometricHodge())
+    dec_hodge_star(n::Int, sd::HasDeltaSet, ::DiagonalHodge)
+    dec_hodge_star(n::Int, sd::HasDeltaSet, ::GeometricHodge)
+    dec_hodge_star(::Type{Val{k}}, sd::HasDeltaSet, ::DiagonalHodge) where {k}
+    dec_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex1D, ::GeometricHodge) where {j}
+    dec_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge) where {j}
+    dec_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, point_type}, ::GeometricHodge) where {float_type, point_type}
+    dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{2}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{2}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+    dec_p_hodge_diag(::Type{Val{3}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+    dec_inv_hodge_star(n::Int, sd::HasDeltaSet; hodge=GeometricHodge())
+    dec_inv_hodge_star(n::Int, sd::HasDeltaSet, ::DiagonalHodge)
+    dec_inv_hodge_star(n::Int, sd::HasDeltaSet, ::GeometricHodge)
+    dec_inv_hodge_star(::Type{Val{k}}, sd::HasDeltaSet, ::DiagonalHodge) where {k}
+    dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex1D, ::GeometricHodge) where {j}
+    dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge) where {j}
+    dec_inv_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge)
+    dec_inv_hodge_star(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge)
+    dec_inv_hodge_star(::Type{Val{3}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge)
+dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) where {j}
+
 ### Description
+
+The hodge star operator maps k-forms to their respective "orthogonal" (n-k)-forms based on the Riemannian metric (or inner product). 'n' is the number of dimensions in the space. It relates the primal mesh to the dual mesh and is an important component in later operators. For example, in 2D space, points are outputted as areas, lines become orthogonal lines, and areas become midpoints of the space. 
+
+The discrete hodge star is computed using a formula which states that the original form evaluated on the original simplex divided by the simplex's magnitude is equivalent to the starred form evaluated on the "orthogonal" simplex divided by the "orthogonal" simplex's magnitude. This formula ensures dual and primal meshes contain the same physical information. The operator is also an isomorphism, meaning the hodge star applied twice to a form will return the original form (with a potential sign change depending on dimensions). 
+
+The operator matrix is calculated through either two methods - the geometric hodge or the diagonal hodge. The geometric hodge is calculated as a sparse, diagonal matrix with elements dependent on the ratio between simplex and orthogonal simplex magnitudes. The matrix dimensions are $|C_k |×|C_k |$. The diagonal hodge is calculated faster but is less accurate.
+
+This operator is metric-dependent. It is reliant on a metric to determine angles and orthogonality. The result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on if the dual mesh is barycentric-centered or circumcentric-centered, the hodge star may return differing results. Furthermore, stretching the mesh would cause changes in simplex magnitudes on primal and dual meshes, thus affecting the output values from the hodge star operator.
+
+Finally, as this operator is metric-dependent, it does not commute fully with respect to natural pullbacks. However, the code attempts to approximate this property as much as possible for accurate simulations.
 
 ### Important Properties
 
+k-form → (n-k)-form
+
+$⟨ω^k, β^k ⟩v=ω^k∧⋆β^k$
+
+The formula above displays the identity of the hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the righthand side. Due to this definition, it is inherantly a metric-dependent operator.
+
+$ 
+\frac{1}{|⋆σ^k |}  
+⟨\starω, ⋆σ^k ⟩ ≔ 
+\frac{1}{|σ^p |}  ⟨ω, σ^k ⟩
+$
+
+The formula above is the definition of the discrete hodge star for $1≤k≤n−1$ forms. It states that the hodge star of a form integrated on the dual of a simplex and divided by the length of that dual simplex must be equal to the form evaluated on the primal simplex, divided by the length of that primal simplex. The dual form maintains the same physical information while transitioning to orthogonality. Forms that do not conform to the inequality have an additional term that changes sign to account for simplex orientation.
+
+$⋆⋆ω=(−1)^k(n−k)ω $
+
+The hodge star operator is an isomorphism. Using the hodge star on a form twice returns it to its original state, with a change in sign depending on dual orientation.
+
 ### Citations
 
+Discrete Exterior Calculus - Hirani  
+Section 4.1 (pp. 40-42)
 
+Discrete Exterior Calculus - Desbrun  
+Section 6 (pp. 14-15)
+
+Notes on Discrete Exterior Calculus  
+Section 2.9 (pp. 12-13)
+
+Discrete Differential Forms  
+Section 5.3-5.4
 
 ## Flat
 

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -17,7 +17,7 @@ The formula above displays the property that the boundary of a boundary is alway
 
 ⟨dω, c⟩ = ⟨ω, ∂c⟩
 
-The boundary operator is dual to the exterior derivative. In fact, the exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the interior product of a chain and a cochain is synonymous to evaluating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
+The boundary operator is dual to the exterior derivative. In fact, exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the interior product of a chain and a cochain is synonymous to evaluating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
 
 ### Citations
 
@@ -27,7 +27,7 @@ Page 10
 Discrete Exterior Calculus
 Section 4.1 (pp. 40-41)
 
-
+ssssssss
 
 
 

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -50,16 +50,16 @@ The formula above displays how the boundary operator is computed/defined in the 
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani
+Discrete Exterior Calculus - Hirani  
 Section 3.6 (pp. 35-36)
 
-Discrete Exterior Calculus - Desbrun
+Discrete Exterior Calculus - Desbrun  
 Section 5 (pp. 13-14)
 
-Notes on Discrete Exterior Calculus
+Notes on Discrete Exterior Calculus  
 Section 2.6 (p. 10)
 
-Discrete Differential Forms
+Discrete Differential Forms  
 Section 3 
 
 ## Exterior Derivative
@@ -139,16 +139,16 @@ The formula above is Generalized Stokes' Theorem. It states that a person can de
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani
+Discrete Exterior Calculus - Hirani  
 Section 3.6 (pp. 35-37)
 
-Discrete Exterior Calculus - Desbrun
+Discrete Exterior Calculus - Desbrun  
 Section 5 (pp. 13)
 
-Notes on Discrete Exterior Calculus
+Notes on Discrete Exterior Calculus  
 Section 2.6 (p. 10-11)
 
-Discrete Differential Forms
+Discrete Differential Forms  
 Section 4.1-4.3
 
 ## Wedge Product
@@ -223,12 +223,56 @@ Section 4.1-4.3
 
 ### Signature
 
+Decapodes.jl
+
+    :L₀ => add_Lie_1D!(Val{0}, ...)  # d ∘ ι (interior then dual derivative)
+    :L₁ => add_Lie_1D!(Val{1}, ...)  # d ∘ ι (same in 1D)
+    :L₂ => add_Lie_2D!(Val{2}, ...)  # d ∘ ι (dual 2-form)
+    
+    :ℒ₁ => ℒ_dd(Tuple{1,1}, sd)      # Full dual-dual Lie: -(d∘ι + ι∘d)
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ℒ(s::HasDeltaSet, X♭::EForm, α::DualForm{n}; kw...) where n
+    lie_derivative_flat(n::Int, s::HasDeltaSet, args...; kw...)
+    lie_derivative_flat(::Type{Val{0}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...)
+    lie_derivative_flat(::Type{Val{1}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...)
+    lie_derivative_flat(::Type{Val{2}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...)
+
+CombinatorialSpaces.jl, FastDEC.jl
+
+    ℒ_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
+
 ### Description
+
+The Lie Derivative operator inputs a k-form and outputs a k-form representing the rate of change of the form as it moves in the direction of a vector field. It is analogous to the directional derivative in vector calculus. A common application for the lie derivative is the formula for advection. 
+
+The Lie Derivative's algebraic definition is displayed in Cartan's Magic Formula, which uses exterior derivative and interior product operators. This smooth formula is used to define the discrete primal-dual lie derivative, where X is a discrete vector field on the primal mesh and ω is a dual k-form.
+
+However, this method may not satisfy the Leibniz Property of Lie Derivatives, as it uses the discrete wedge product operator (within the interior product operator). This operator is only associative on closed forms. 
+
+Hirani notes an alternative flow-out definition in Section 8.5 in his thesis, Discrete Exterior Calculus, which does not suffer from this lack of associativity. However, this definition is not covered here.
 
 ### Important Properties
 
+k-form → k-form
+
+$L_X ω=i_X (dω)+d(i_X ω)$
+
+This formula displays Cartan's Magic Formula, or an algebraic definition of the lie derivative using the interior product and the exterior derivative operators. This formula helps define the discrete primal-dual lie derivative operator on a simplicial complex. X is a discrete primal vector field and ω is a dual p-form.
+
+
+$L_X (ω∧β)=L_X (ω)∧β+ω∧L_X (β)$
+
+This is the Leibniz Property of the lie derivative, which displays the lie derivative's relationship with wedge product in the smooth case. In the discrete case, if the algebraic definition of the interior product is used, this relationship might not always be correct. This is because the algebraic interior product is defined using the wedge product. As the wedge product is only associative on closed forms (in the discrete setting), there may be errors in this Leibniz property.
+
 ### Citations
 
+Discrete Exterior Calculus - Hirani  
+Section 8.4-8.5 (pp. 83-85)
+
+Discrete Exterior Calculus - Desbrun  
+Section 10 (pp. 25-26)
 
 ## Laplace-Beltrami
 
@@ -284,16 +328,18 @@ It is represented as a sparse matrix. Due to its reliance on the codifferential 
 
 k-form → k-form
 
-Δ=dδ+δd
-This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, ∇f=δdf, is a special situation for 0-form functions, where d(δf)=0 as the codifferential of a 0-form is always zero.
+$Δ=dδ+δd$
 
-⟨Δf, σ^0 ⟩=1/|⋆σ^0 |  ∑_(σ^1=[σ^0, v])▒〖|⋆σ^1 |/|σ^1 | (f(v)−f(σ^0 ))〗
-This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex σ^0  (⟨Δf, σ^0 ⟩) can be evaluated by the sum/contribution of all edges bordering σ^0, each weighted by the length of their corresponding dual edge divded by their primal length (|⋆σ^1 |/|σ^1 | ), and then multiplied by the difference between the form at the evaluated vertex (f(σ^0)) and the neighboring vertex (f(v)), connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell (1/|⋆σ^0 | ) to normalize it. This formula matches with another geometric Laplace-Beltrami formula that uses cotangents and indices.
+This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $∇f=δdf$, is a special situation for 0-form functions, where $d(δf)=0$ as the codifferential of a 0-form is always zero.
+
+$⟨Δf, σ^0 ⟩ =\frac{1}{ |\sigma_o| }  ∑_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
+
+This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex $σ^0$,  $(⟨Δf, σ^0 ⟩)$ can be evaluated by the sum/contribution of all edges bordering $σ^0$, each weighted by the length of their corresponding dual edge divded by their primal length $(|⋆σ^1 |/|σ^1 | )$, and then multiplied by the difference between the form at the evaluated vertex $(f(σ^0))$ and the neighboring vertex $(f(v))$, connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell $(1/|⋆σ^0 | )$ to normalize it. This formula matches with another geometric Laplace-Beltrami formula that uses cotangents and indices.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani
+Discrete Exterior Calculus - Hirani  
 Section 6.4 (pp. 68-70)
 
-Discrete Exterior Calculus - Desbrun
+Discrete Exterior Calculus - Desbrun  
 Section 10 (pp. 26-27)

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -356,7 +356,7 @@ Finally, as this operator is metric-dependent, it does not commute fully with re
 
 k-form → (n-k)-form
 
-$⟨ω^k, β^k ⟩v=ω^k∧⋆β^k$
+$ ⟨ω^k, β^k ⟩v=ω^k∧⋆β^k $
 
 The formula above displays the identity of the hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the righthand side. Due to this definition, it is inherantly a metric-dependent operator.
 
@@ -390,46 +390,222 @@ Section 5.3-5.4
 
 ### Signature
 
+Decapodes.jl
+
+    :♭ᵈᵖ => dec_♭(sd)                    # Dual-to-primal flat
+    :♭♯ => ♭♯_mat(sd) |> matmul          # Dual 1-form → primal 1-form interpolation
+
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ♭(s::HasDeltaSet, X::DualVectorField)
+    ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::DPPFlat)
+    ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::PPFlat)
+    ♭_mat(s::AbstractDeltaDualComplex2D, f::DPPFlat)
+    ♭_mat(s::AbstractDeltaDualComplex2D, p2s, ::DPPFlat)
+    ♭_mat(s::AbstractDeltaDualComplex2D, ::PPFlat)
+
+CombinatorialSpaces.jl, FastDEC.jl
+
 ### Description
+
+The flat operator is a musical isomorphism that linearly maps vector fields to 1-forms. In the smooth case, it is the inverse of the sharp operator. In the discrete case, it has no exact inverse. It is often used to define certain vector quantities as forms, such as fluid flow.
+
+The smooth definition of the flat operator is reliant on an inner product, making the operator metric-dependent. Due to the existence of primal meshes, dual meshes, and differing interpolation methods, there are a total of eight different discrete flat operators. An example is the $♭_{dpp}$  operator, or the dual-primal-primal operator. This operator inputs dual vector fields, uses dual-primal interpolation, and outputs cochains on the primal mesh. For non-flat meshes, the use of operators that input vector fields on the dual mesh is preferred. The operator is represented as a sparse mesh.
 
 ### Important Properties
 
+k-vector → k-form
+
+$⟨X, v⟩=X^♭ (v)$
+
+The formula above displays the definition of the smooth flat operator. The inner product of the vector field with another vector should be equivalent to the vector 
+
+$ ⟨X^(♭_{dpp} ), σ^1 ⟩ = ∑_{σ^n≻ σ^1}▒〖|∗σ^1∩σ^n |/|∗σ^1 |  X(σ^n )⋅(σ^1 ) ̃ 〗$
+
+The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge (∑_(σ^n≻ σ^1)▒ ), determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell (|∗σ^1∩σ^n |/|∗σ^1 | ). Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge (X(σ^n )⋅(σ^1 ) ̃). Finally, sum all contibutions.
+
 ### Citations
 
+Discrete Exterior Calculus - Hirani  
+Section 5.3-5.6 (pp. 46-54)
+
+Discrete Exterior Calculus - Desbrun  
+Section 7 (p. 16)
+
+Notes on Discrete Exterior Calculus  
+Section 2.12 (pp. 14-15)
 
 ## Sharp
 
 ### Signature
 
+Decapodes.jl
+
+    :♯ᵖᵈ => dec_♯_pd(sd)                 # Primal-dual sharp (1D only)
+    :♯ᵖᵖ => dec_♯_pp(sd)                 # Primal-primal sharp (AltPPSharp in 2D)
+    :♯ᵈᵈ => dec_♯_dd(sd)                 # Dual-dual sharp (LLSDDSharp)
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    ♯(s::HasDeltaSet2D, α::EForm)
+    ♯(s::HasDeltaSet2D, α::DualForm{1})
+    ♯(s::AbstractDeltaDualComplex1D, X::AbstractVector, ::PDSharp)
+    ♯(s::AbstractDeltaDualComplex1D, X::AbstractVector, ::PPSharp)
+    ♯(s::AbstractDeltaDualComplex2D, α::AbstractVector, DS::DiscreteSharp)
+    ♯(s::AbstractDeltaDualComplex2D, α::AbstractVector, ::LLSDDSharp)
+    ♯_mat(s::AbstractDeltaDualComplex2D, DS::DiscreteSharp)
+    ♯_mat(s::AbstractDeltaDualComplex2D, ::LLSDDSharp)
+    ♯_denominator(s::AbstractDeltaDualComplex2D, v::Int, t::Int, ::DiscreteSharp)
+    ♯_denominator(s::AbstractDeltaDualComplex2D, v::Int, _::Int, ::AltPPSharp)
+    get_orthogonal_vector(s::AbstractDeltaDualComplex2D, v::Int, e::Int)
+    ♭♯(s::HasDeltaSet2D, α::SimplexForm{1})
+    ♭♯_mat(s::HasDeltaSet2D)
+    
+CombinatorialSpaces.jl, FastDEC.jl
+
 ### Description
+
+The sharp operator is a musical isomorphism that linearly maps 1-forms to vector fields. In the smooth case, it is the inverse of the flat operator. In the discrete case, it has no exact inverse. It is used as a component in the interior product and Lie Derivative operators.
+
+As the smooth definition of the sharp operator is reliant on the inner product, it is a metric operator. There are a total of four different discrete sharp operators to account for form inputs and vector outputs on the primal and dual meshes. It is represented as a sparse mesh. 
+
+The sharp vector turns k-forms into k-vectors. In the smooth case, it is inverses with the flat operator. The discrete sharp operator(s) lack this inverse.
 
 ### Important Properties
 
+k-form → k-vector
+
+$ ⟨ω^{\sharp}, v⟩= ω(v) $
+
+The formula above displays the definition of the smooth sharp operator. The inner product of the sharped form with a different vector should be equivalent to the vector being inputted into the regular form.
+
 ### Citations
 
+Discrete Exterior Calculus  
+Chapter 5.7-5.8 (pp. 54-56)
 
+Discrete Exterior Calculus - Desbrun  
+Section 7 (p. 16)
 
 ## Codifferential
 
 ### Signature
 
+Decapodes.jl
+
+    :δ₁ => add_Codiff!(d, src, tgt)  # Expands to ⋆ → d → ⋆ (with correct dual/primal flips)
+    :δ₂ => add_Codiff!(d, src, tgt)
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    δ(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n
+    δ(n::Int, s::HasDeltaSet, args...; kw...)
+    δ(::Type{Val{n}}, s::HasDeltaSet; hodge::DiscreteHodge=GeometricHodge(), matrix_type::Type=SparseMatrixCSC{Float64}) where n
+    δ(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; hodge::DiscreteHodge=GeometricHodge()) where n
+    δ(::Type{Val{n}}, s::HasDeltaSet, ::DiagonalHodge, args...) where n
+    δ(::Type{Val{n}}, s::HasDeltaSet, ::GeometricHodge, matrix_type) where n
+    δ(::Type{Val{n}}, s::HasDeltaSet, ::GeometricHodge, form::AbstractVector) where n
+
+CombinatorialSpaces.jl, FastDEC.jl
+
 ### Description
+
+The codifferential operator serves as the adjoint of the exterior derivative. It maps k-forms to (k-1)-forms. This operator is used to represent divergence and as a component of the Laplace-Beltrami operator.
+
+This operator is metric due to the reliance of the hodge star in its defintion. It is represented as a sparse matrix created by combining hodge star and exterior derivative matrices and accounting for orientation. 
+
+In the smooth setting, the codifferential is the adjoint of the exterior derivative operator. This property is retained in the discrete setting as well. It is defined through hodge star and exterior derivative operators. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation. This operator is also used as a part of the algebraic definition of the Laplace-Beltrami operator. 
+
+Finally, due to the prescence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. Due to inaccuracies in the discrete hodge star, the discrete codifferential applied twice is approximately zero.
 
 ### Important Properties
 
+k-form → (k-1)-form
+
+$ δf=0 $
+The formula above shows that the codifferential of a 0-form f is equal to zero. The codifferential operator takes a k-form and outputs a (k-1)-form. There is no such thing as a (-1)-form, so the operation outputs zero.
+
+$ δω=(−1)^{n(k−1)+1}⋆d⋆ω $
+
+The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  decides the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
+
+$ ⟨dω, β⟩=⟨ω, δβ⟩ $
+
+The exterior derivative and codifferential are adjoint in both the smooth and discrete settings. 
+
 ### Citations
 
+Discrete Exterior Calculus - Hirani  
+Section 4.2 (p. 42)
+
+Discrete Exterior Calculus - Desbrun  
+Section 6 (p. 15)
+
+Discrete Differential Forms   
+Section 5.5
 
 ## Interior Product
 
 ### Signature
 
+Decapodes.jl
+
+    :i₁ => add_Inter_Prod_1D! or add_Inter_Prod_2D!(Val{1}, ...)  # Expands to ⋆⁻¹ → ∧ → ⋆
+    :i₂ => add_Inter_Prod_2D!(Val{2}, ...)                         # Same, no sign flip
+    
+    :ι₁₁ => interior_product_dd(Tuple{1,1}, sd)   # Dual-dual: ⋆₂ ∧₁₁ ⋆₁⁻¹
+    :ι₁₂ => interior_product_dd(Tuple{1,2}, sd)   # Dual-dual: ⋆₁ (♭♯ ∧₀₁ ⋆₀⁻¹)
+
+CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
+
+    interior_product(s::HasDeltaSet, X♭::EForm, α::DualForm{n}; kw...) where n
+    interior_product_flat(n::Int, s::HasDeltaSet, args...; kw...)
+    interior_product_flat(::Type{Val{n}}, s::HasDeltaSet, X♭::AbstractVector, α::AbstractVector; kw...) where n
+
+CombinatorialSpaces.jl, FastDEC.jl
+
+    interior_product_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
+    interior_product_dd(::Type{Tuple{1,2}}, s::SimplicialSets.HasDeltaSet)
+
+
 ### Description
+
+The interior product contracts a vector field with a k-form, outputting a (k-1)-form. It is an operator that "combines" forms and vector fields together by plugging in the field into one of the form's inputs. In differential geometry, forms are measurement tools that input vectors and output scalar values. The interior product makes use of this definition to merge vector fields and forms together.
+
+In the smooth setting, it is a topological operator. However, using the algebraic definition, this tool becomes metric due to its reliance on the flat and hodge star operators.
+
+Due to the use of the wedge product in its definition, the Leibniz Property for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie Derivative, which faces this limitation as well. 
+
+Hirani notes the existence of an extrusion definition for this operator which is not covered in this description. 
 
 ### Important Properties
 
+k-form → (k-1)-form
+
+$ i_X ω(X_1, …, X_k )=ω(X, X_1. …, X_k ) $
+
+The above definition shows the algebraic definition of the interior product. This operator contracts a vector field with a k-form, "inserting" itself into one of the slots of the form. The output is a (k-1)-form.
+
+$ i_X ω=(−1)^k(n−k) ⋆(⋆ω∧X^♭ ) $
+
+The above identity displays the interior product operator composed of hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The wedge product, hodge star, and flat operations $(⋆ω∧X^{\flat})$ represents inserting the contribution of vector field X into the form ω. The exterior hodge star returns the result to its proper dimension, k+1. Finally, the $(−1)^k(n−k)$ accounts for changes in orientation due to the hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Property for contraction will only apply to closed forms (where $dω=0$), as the discrete wedge product is only associative on closed forms.
+
+$ i_X (f) = 0 $
+
+The interior product of a 0-form f with a vector field X is always zero.
+
+$ i_X (ω^k ∧ β^l )=(i_X ω)∧β+(−1)^k ω∧(i_X β) $
+
+The interior product follows the Leibniz Rule. For non-closed forms, it is important to note that the discrete wedge product is not associative and thus errors in this rule may appear.
+
 ### Citations
 
+Discrete Exterior Calculus - Hirani  
+Section 8.2-8.3 (pp. 79-83)
+
+Discrete Exterior Calculus - Desbrun  
+Section 10 (pp. 24-26)
 
 ## Lie Derivative
 

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -1,26 +1,19 @@
 # Discrete Exterior Calculus Operator Table
 
-Preface: This document is meant to provide simplified descriptions of the operators of Discrete Exterior Calculus. The reader can find more rigorous definitions in the referenced sources for each operator.
+This document is meant to provide simplified descriptions of the operators of Discrete Exterior Calculus. The reader can find more rigorous definitions in the referenced sources for each operator. The links to the sources referenced for the operators are below:
 
-Here are the links to the sources referenced for the operators below:
+[Discrete Exterior Calculus](https://www.cs.jhu.edu/~misha/Fall09/Hirani03.pdf) - Hirani
 
-Discrete Exterior Calculus - Hirani
-https://www.cs.jhu.edu/~misha/Fall09/Hirani03.pdf
 
-Discrete Exterior Calculus - Desbrun et. al.
-https://arxiv.org/abs/math/0508341
+[Discrete Exterior Calculus](https://arxiv.org/abs/math/0508341) - Desbrun et. al.
 
-Notes on Discrete Exterior Calculus - Gillette
-https://math.arizona.edu/~agillette/research/decNotes.pdf
+[Notes on Discrete Exterior Calculus](https://math.arizona.edu/~agillette/research/decNotes.pdf) - Gillette
 
-Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
-https://geometry.caltech.edu/pubs/DKT05.pdf
+[Discrete Differential Forms for Computational Modeling](https://geometry.caltech.edu/pubs/DKT05.pdf) - Desbrun et. al.  
 
 ## Boundary
 
 ### Signature
-
-Decapodes.jl
 
 CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
 
@@ -40,9 +33,9 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 The boundary operator acts on the geometry of the mesh, linearly mapping k-chains to (k-1)-chains. It relates to the important exterior derivative operator via duality, and helps compute the operator through Generalized Stokes' Theorem.
 
-This operator inputs k-chains and outputs (k-1)-chains (or k-manifolds to (k-1)-manifolds in the smooth case). For example, it would input a 1-chain, representing a line, into the two endpoints of that line. This operator has nilpotency, meaning the boundary operator applied to that same geometry is always zero. This property is important in the exterior derivative in preserving geometric invariants and physical conservation laws. 
+This operator inputs k-chains and outputs (k-1)-chains (or k-manifolds to (k-1)-manifolds in the smooth case). For example, it could map a 1-chain, representing a line, to the two endpoints of that line. This operator has nilpotency, meaning the boundary operator applied to the same geometry is always zero. This property is important in the exterior derivative for preserving geometric invariants and physical conservation laws. 
 
-This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_{k−1} |×|C_k |$, meaning it inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. It does not require global information of the entire mesh to compute it. The computation of this operator is local, topological, and coordinate-free. As the geometric intuition for this matrix calculation is difficult to describe, I recommend further investigation online.
+This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_{k−1} |×|C_k |$. It inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. The computation of this operator is local, topological, and coordinate-free. As the geometric intuition for this matrix calculation is difficult to describe, I recommend further investigation online.
 
 This tool is important in defining the exterior derivative operator through Generalized Stokes' Theorem. This theorem states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. Using this definition and the boundary operator's duality, the exterior derivative is the transpose of the boundary matrix. 
 
@@ -50,34 +43,34 @@ Finally, this operator is natural with respect to discrete pullbacks. This state
 
 ### Important Properties
 
-$C_k(K; \Z) \rightarrow C_{k - 1} (K; \Z) $
+$ \partial^k: Cₖ(K; ℤ) → Cₖ₋₁(K; ℤ) $  
 
-The boundary operator linearly inputs linear combinations of k-chains (integers with respect to simplex orientation, represented by $ \Z $) on mesh K and outputs the combined (k-1)-chain sum of the boundary of those k-chains.
+The boundary operator linearly inputs linear combinations of k-chains (integers with respect to simplex orientation, represented by $ \Z $) on mesh K and outputs the combined (k-1)-chain sum of the boundary of those k-chains.  
 
 $ ∂(∂c) = 0 $
 
-The formula above displays the property of nilpotency for the boundary operator. In other words, the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to discrete chains as well.
+The formula above displays the property of nilpotency for the boundary operator. In other words, the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to chains as well.
 
 $ ⟨dω, c⟩ = ⟨ω, ∂c⟩ $
 
-The boundary operator is dual to the exterior derivative. In fact, the exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the inner product of a chain and a cochain is synonymous to integrating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
+The boundary operator is dual to the exterior derivative. In fact, the exterior derivative is defined as the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the inner product of a chain and a cochain is synonymous to integrating the cochain on the chain, not requiring a metric. It is also the discrete analogue of integrating a form over a region.
 
-$ \partial[v_o, v_1, ..., v_k] = \sum^k_{i=0}(-1)^i[v_o, ..., v_i, ..., v_k] $
+$ ∂[v₀, v₁, …, vₖ] = ∑ᵏᵢ₌₀ (−1)ⁱ [v₀, …, v̂ᵢ, …, vₖ] $  
 
 The formula above displays how the boundary operator is computed/defined in the discrete setting. The operator inputs a chain with a particular ordering of vertices, where edges may look like $e=[v_0, v_1]$ and faces may look like $σ=[v_0, v_1, v_2]$. Let's assume the operator inputs the triangular face $σ_o=[v_0, v_1, v_2]$ surrounded by the edges $e_0=[v_0, v_1]$, $e_1=[v_1, v_2]$, and $e_2=[v_o, v_2]$. The boundary operator omits the i-th vertex of the face for each iteration. The operation determines the sign of this edge based on if 'i' is even or odd. For this face $σ_o$, the result $∂[v_o, v_1, v_2 ]=[v_1, v_2 ]−[v_o, v_2 ]+[v_o, v_1 ]=e_1−e_2+e_o$. If the reader creates a visual representation of the face and surrounding vertices, with orientations going from the first vertex and moving to the last, the result will be the same.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 3.6 (pp. 35-36)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 5 (pp. 13-14)
 
-Notes on Discrete Exterior Calculus - Gillette  
+Notes on Discrete Exterior Calculus - Gillette\
 Section 2.6 (p. 10)
 
-Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.\
 Section 3 
 
 ## Exterior Derivative
@@ -117,56 +110,56 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 The exterior derivative operator (ED) extends the idea of differentiation into differential geometry. It generalizes vector calculus concepts such as gradient, divergence, and curl onto multidimensional forms. It is a requirement for modelling any partial differential equation in an exterior calculus framework.
 
-This operator maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the ED operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. The ED on a 3-form in 3D space is always zero.
+This operator linearly maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the ED operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. The ED on a 3-form in 3D space is always zero.
 
 This operator matrix is calculated with Generalized Stokes' Theorem, which states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. In the discrete setting, the exterior derivative for a cochain is the transpose of the boundary matrix operator for its respective chain. Like the boundary operator, it is a sparse matrix with elements 0, +1, and -1. The computation of this operator is local, topological, and coordinate-free.
 
-Using geometric intuition, this operator determines the dimensional rate of change of a form based on the values of the forms around it. For example, imagine three cochains attached to 1-simplexes (lines) that form a triangle. The exterior derivative of the 1-cochain formed from the three values is a 2-cochain residing on the triangular face, calculated by adding the cochains together and accounting for differing orientation.
+This operator determines the dimensional rate of change of a form based on the values of the forms around it. For example, imagine three cochains attached to 1-simplexes (lines) that form a triangle. The exterior derivative of the 1-cochain formed from the three values is a 2-cochain residing on the triangular face, calculated by adding or subtracting the cochains together depending on face and edge orientations. 
 
 Furthermore, the exterior derivative shares the property of nilpotency with its dual operator. Thus, the exterior derivative applied twice to the same form is always zero. This trait ingrains geometrical information and mathematical conservation properties, such as the curl of a form's divergence always being zero. 
 
 On a dual mesh, the discrete exterior derivative may change in sign to account for the mesh's differing orientation. This formula is displayed in the Important Properties section.
 
-Finally, this operator is natural with respect to discrete pullbacks, like the boundary. It also has an adjoint with the codifferential operator, allowing for the Laplacian and Hodge decompositions.
+Finally, this operator is natural with respect to discrete pullbacks, like the boundary. It also has an adjoint with the codifferential operator, allowing for Hodge Decompositions and the Laplacian.
 
 ### Important Properties
 
-$ \Omega_d^k (K) \rightarrow \Omega_d^{p + 1} (K) $
+$ d^k: \Omega\_{d}^k (K) \rightarrow \Omega\_{d}^{k + 1} (K) $
 
-The discrete exterior derivative linearly maps discrete k-forms on mesh K to discrete (k+1)-forms on the same mesh K.
+The discrete exterior derivative linearly maps discrete k-forms on mesh K to discrete (k+1)-forms on mesh K.
 
 $ d(dω)=0 $
 
-This is the property that the exterior derivative applied twice to the same form is always zero. This property retains the mathematical properties of $∇×∇f=0$ and $∇ ⋅∇×f=0$ without requiring any additional features. 
+The exterior derivative applied twice to the same form is always zero. This property retains the PDE's mathematical structure (geometric invariants, $∇×∇f=0$, and $∇ ⋅∇×f=0$) without requiring any additional features. 
 
-$ d(ω∧β) = dω ∧ β+(−1)^{deg⁡(ω)} ω ∧ β $
+$ d(ω∧β) = dω ∧ β + (−1)^{deg⁡(ω)} ω ∧ β $
 
-The formula above displays the Leibniz Principle of exterior derivatives. It shows how the operator interacts with the wedge product.
+The formula above displays the Leibniz Principle of exterior derivatives. The operator has a product-rule-like relationship with the wedge product.
 
 $ d=∂^T $
 
 In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs k-forms and outputs the exterior derivative values of (k+1)-forms.
 
-$ \tilde{d}_{n−k} = (−1)^k (d_{k−1} )^T $
+$ \tilde{d}\_{n−k} = (−1)^k (d\_{k−1} )^T $ 
 
-Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction, where $\tilde{d} $ represents the dual exterior derivative operator.
+Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction, where $ \tilde{d} $ represents the dual exterior derivative operator.
 
-$ \int_\Omega d\omega=\int_{\partial\Omega}\omega $
+$ \int \_{\Omega} d\omega = \int \_{\partial\Omega}\omega $ 
 
-The formula above is Generalized Stokes' Theorem. It states that a person can determine the exterior derivative of a form across a manifold by determining the value of that across the boundary of the manifold. As the exterior derivative generalizes the gradient, divergence, and the curl. Generalized Stokes' Theorem combines Stokes' Theorem, Green's Theorem, and the Divergence Theorem into one expression.
+The formula above is Generalized Stokes' Theorem. It states that a person can determine the exterior derivative of a form across a manifold by determining the value of that across the boundary of the manifold. Thus, the exterior derivative generalizes the gradient, divergence, and the curl while Generalized Stokes' Theorem generalizes Stokes' Theorem, Green's Theorem, and the Divergence Theorem into one expression.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 3.6 (pp. 35-37)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 5 (pp. 13)
 
-Notes on Discrete Exterior Calculus - Gillette   
+Notes on Discrete Exterior Calculus - Gillette\
 Section 2.6 (p. 10-11)
 
-Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.\
 Section 4.1-4.3
 
 ## Wedge Product
@@ -175,7 +168,7 @@ Section 4.1-4.3
 
 Decapodes.jl
 
-    :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)  # Returns (in-place kernel, out-of-place)
+    :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)  
     :∧₁₀ => dec_pair_wedge_product(Tuple{1,0}, sd)
     :∧₀₂ => dec_pair_wedge_product(Tuple{0,2}, sd)
     :∧₂₀ => dec_pair_wedge_product(Tuple{2,0}, sd)
@@ -234,30 +227,30 @@ It is an anti-commutative operator, meaning $β∧ω$ is often equal to $−ω�
 
 Another limitation is the wedge product's reliance on the metric. Certain operator formulas may require defined angles for calculating the result of this operator. However, other formulas may lack this limitation. Formulas that are not metric-dependent are natural with respect to discrete pullbacks.
 
-Finally, the Leibniz Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas. 
+Finally, the Leibniz Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas shown below. 
 
 ### Important Properties
 
-$ \Omega^k_d (K) \times \Omega^l_d (K) \rightarrow \Omega^{k + l}_d (K) $
+$ \wedge:\Omega^k\_d (K) \times \Omega^l\_d (K) \rightarrow \Omega^{k + l}\_d (K) $
 
 The discrete primal-primal wedge product inputs a discrete primal k-form and discrete primal l-form on mesh K and outputs a discrete (k+l)-form on mesh K. The discrete dual-dual wedge product and discrete primal-dual wedge product would be defined differently.
 
 $ 
-\langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
+\langle \omega^k \wedge \beta^l, \sigma^{k+l} \rangle := 
 \frac{1}{(k+l)!} 
-\sum_{r\in S_{k+l+1}} sign(\tau) \frac{|\sigma^{k+l} \cap \star v_{\tau(k)}|}{|\sigma^{k+l}|} 
-\langle \omega, [v_{\tau(0)}, ..., v_{\tau(k)}] \rangle 
-\langle \beta, [v_{\tau(k)}, ..., v_{\tau(k+l)}] \rangle 
+\sum\_{r\in S\_{k+l+1}} sign(\tau) \frac{|\sigma^{k+l} \cap \star v\_{\tau(k)}|}{|\sigma^{k+l}|} 
+\langle \omega, [v\_{\tau(0)}, ..., v\_{\tau(k)}] \rangle 
+\langle \beta, [v\_{\tau(k)}, ..., v\_{\tau(k+l)}] \rangle 
 $
 
 This is the metric formulation for the discrete primal-primal wedge product operator, where ω is a is a discrete primal k-form and β is a discrete primal l-form. The LHS states that the evaluation of the wedge product of two forms on the appropriate face is equal to the RHS. The RHS states that for each permutation of the simplex $σ^{k+l}$  (where there are $(k+l+1)!$  orderings of the vertices), it finds the sign of that permutation $(sign(τ))$ and multiplies it by a geometric weight $(|σ^{k+l}∩⋆v_τ (k)| / |σ^(k+l) | )$. The weight determines the volume of the new simplex that is shared by the simplices touching the k-th vertex of the current permutation, divided by the volume of the new simplex. Finally, it multiplies this weight by the inner product of ω on a k-simplex formed from initial vertices $(⟨ω, [v_τ(0) , …, v_τ(k) ]⟩)$ and the inner product of β on a l-simplex formed from the vertices afterwards $(⟨β, [v_τ(k) , …, v_τ(k+l) ]⟩)$. The contributions from each permutation are summed together and normalized based on the forms' dimensions $(1/(k+l)!)$. As this formula relies on simplex magnitudes, it is metric.
 
 $ 
-\langle \omega^k \wedge \beta^l, \sigma^{k+l}\rangle := 
+\langle \omega^k \wedge \beta^l, \sigma^{k+l} \rangle := 
 \frac{1}{(k+l+1)!} 
-\sum_{r\in S_{k+l+1}} sign(\tau)  
-\langle \omega, [v_{\tau(0)}, ..., v_{\tau(k)}] \rangle 
-\langle \beta, [v_{\tau(k)}, ..., v_{\tau(k+l)}] \rangle 
+\sum\_{r\in S\_{k+l+1}} sign(\tau)  
+\langle \omega, [v\_{\tau(0)}, ..., v\_{\tau(k)}] \rangle 
+\langle \beta, [v\_{\tau(k)}, ..., v\_{\tau(k+l)}] \rangle 
 $
 
 The formula above is the topological primal-primal wedge product operator. It follows the same trend as the metric case. However, this one does not use a geometric weighing factor, and instead accounts for weight with normalization $(1/(k+l+1)!)$. 
@@ -266,13 +259,13 @@ $ ω∧β=(−1)^{deg⁡(ω)deg⁡(β)}⁡(β∧ω) $
 
 This formula displays the anti-commutative property of wedge product. Switching the order of the forms on the wedge product may swap the sign of the resulting higher degree form. This is the extension of the idea that forms are antisymmetric tensors, and swapping the forms that create a higher form change the orientation of the area/volume/length.
 
-$ (ω∧β)∧γ=ω∧(β∧γ) $
+$ (ω∧β)∧γ = ω∧(β∧γ) $
 
 This formula displays the associative property of the wedge product operator in the smooth case. In the discrete case, this is only true for closed forms. The exterior derivative of a closed form is zero.
 
 $ d(ω∧β) = dω ∧ β+(−1)^{deg⁡(ω)} ω ∧ β $
 
-As displayed in the exterior derivative section, the Leibniz Rule underscores the interaction between the exterior derivative and the wedge product operators. 
+As displayed in the exterior derivative section, the Leibniz Rule defines the interaction between the exterior derivative and the wedge product operators. 
 
 $ ω ∧ ω = 0 $
 
@@ -280,10 +273,10 @@ This formula shows the alternating property of wedge product in the smooth case.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 7.1-7.3 (pp. 71-76)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 8 (pp. 17-21)
 
 ## Hodge Star
@@ -360,50 +353,50 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The hodge star operator maps k-forms to their respective "orthogonal" (n-k)-forms based on the Riemannian metric (or inner product). 'n' is the number of dimensions in the space. It relates the primal mesh to the dual mesh and is an important component in later operators. For example, in 2D space, points are outputted as areas, lines become orthogonal lines, and areas become midpoints of the space. 
+The hodge star operator maps k-forms to their respective "orthogonal" (n-k)-forms based on the Riemannian metric (or inner product). 'n' is the number of dimensions in the space. It relates the primal mesh to the dual mesh. For example, in 2D space, points are outputted as areas, lines become orthogonal lines, and areas become midpoints of the space. It is also an important component in later operators.
 
-The discrete hodge star is computed using a formula which states that the original form evaluated on the original simplex divided by the simplex's magnitude is equivalent to the starred form evaluated on the "orthogonal" simplex divided by the "orthogonal" simplex's magnitude. This formula ensures dual and primal meshes contain the same physical information. The operator is also an isomorphism, meaning the hodge star applied twice to a form will return the original form (with a potential sign change depending on dimensions). 
+The discrete hodge star is computed using a formula which states that the original form evaluated on the original simplex divided by the simplex's magnitude is equivalent to the starred form evaluated on the "orthogonal" simplex divided by the "orthogonal" simplex's magnitude. This formula ensures dual and primal meshes contain the same information. The operator is also an isomorphism, meaning the hodge star applied twice to a form will return the original form (with a potential sign change depending on dimensions). 
 
-The operator matrix is calculated through either two methods - the geometric hodge or the diagonal hodge. The geometric hodge is calculated as a sparse, diagonal matrix with elements dependent on the ratio between simplex and orthogonal simplex magnitudes. The matrix dimensions are $|C_k |×|C_k |$. The diagonal hodge is calculated faster but is less accurate.
+The operator matrix is calculated through either two methods - the geometric hodge or the diagonal hodge. The geometric hodge is calculated as a sparse, symmetrical matrix with elements dependent on the ratio between simplex and orthogonal simplex magnitudes. It pairs well with barycentric dual mesh centering. The matrix dimensions are $|C_k |×|C_k |$. The diagonal hodge is a diagonal matrix with the same dimensions. It is calculated faster but has less accuracy. It pairs well with circumcentric dual mesh centering.
 
-This operator is metric-dependent. It is reliant on a metric to determine angles and orthogonality. The result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on if the dual mesh is barycentric-centered or circumcentric-centered, the hodge star may return differing results. Furthermore, stretching the mesh would cause changes in simplex magnitudes on primal and dual meshes, thus affecting the output values from the hodge star operator.
+This operator is metric-dependent. It is reliant on a metric to determine angles and orthogonality. Thus, the result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on if the dual mesh is barycentric-centered or circumcentric-centered, the hodge star may return differing results. Furthermore, stretching the mesh would cause changes in simplex magnitudes on primal and dual meshes, thus affecting the output values from the hodge star operator.
 
 Finally, as this operator is metric-dependent, it does not commute fully with respect to natural pullbacks. However, the code attempts to approximate this property as much as possible for accurate simulations.
 
 ### Important Properties
 
-$ \Omega^k_d (K) \rightarrow \Omega^{n - k}_d (\star K) $
+$ *^k:\Omega^k\_d (K) \rightarrow \Omega^{n - k}\_d (\star K) $
 
-The discrete hodge star linearly maps discrete k-forms on mesh K to discrete (n-k)-forms on dual mesh $ \star $ K, where n is the number of dimensions of the space.
+The discrete hodge star linearly maps discrete k-forms on mesh K to discrete (n-k)-forms on dual mesh $ \star K$, where n is the number of dimensions of the space. The $ \star $ symbol acts on geometry and outputs its dual version.
 
-$ ⟨ω^k, β^k ⟩v = ω^k∧⋆β^k $
+$ ⟨ω^k, β^k ⟩v = ω^k∧*β^k $
 
 The formula above displays the identity of the hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the right-hand side. Due to this definition, it is inherently a metric-dependent operator.
 
 $ 
 \frac{1}{|⋆σ^k |}  
-⟨\starω, ⋆σ^k ⟩ ≔ 
-\frac{1}{|σ^p |}  ⟨ω, σ^k ⟩
+⟨*ω, ⋆σ^k ⟩ ≔ 
+\frac{1}{|σ^k |}  ⟨ω, σ^k ⟩
 $
 
 The formula above is the definition of the discrete hodge star for $1≤k≤n−1$ forms. It states that the hodge star of a form integrated on the dual of a simplex and divided by the length of that dual simplex must be equal to the form evaluated on the primal simplex, divided by the length of that primal simplex. The dual form maintains the same physical information while transitioning to orthogonality. Forms that do not conform to the inequality have an additional term that changes sign to account for simplex orientation.
 
-$⋆⋆ω=(−1)^k(n−k)ω $
+$ **ω = (−1)^k (n−k)ω $
 
 The hodge star operator is an isomorphism. Using the hodge star on a form twice returns it to its original state, with a change in sign depending on dual orientation.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 4.1 (pp. 40-42)
 
-Discrete Exterior Calculus - Desbrun et. al.
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 6 (pp. 14-15)
 
-Notes on Discrete Exterior Calculus - Gillette  
+Notes on Discrete Exterior Calculus - Gillette\
 Section 2.9 (pp. 12-13)
 
-Discrete Differential Forms for Computational Modeling - Desbrun et. al.  
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.\
 Section 5.3-5.4
 
 ## Flat
@@ -425,36 +418,39 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     ♭_mat(s::AbstractDeltaDualComplex2D, p2s, ::DPPFlat)
     ♭_mat(s::AbstractDeltaDualComplex2D, ::PPFlat)
 
-CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
 The flat operator is a musical isomorphism that linearly maps vector fields to 1-forms. In the smooth case, it is the inverse of the sharp operator. In the discrete case, it has no exact inverse. It is often used to define certain vector quantities as forms, such as fluid flow.
 
-The smooth definition of the flat operator is reliant on an inner product, making the operator metric-dependent. Due to the existence of primal meshes, dual meshes, and differing interpolation methods, there are a total of eight different discrete flat operators. An example is the $♭_{dpp}$  operator, or the dual-primal-primal operator. This operator inputs dual vector fields, uses dual-primal interpolation, and outputs cochains on the primal mesh. For non-flat meshes, the use of operators that input vector fields on the dual mesh is preferred. The operator is represented as a sparse mesh.
+The smooth definition of the flat operator is reliant on an inner product, making the operator metric-dependent. Due to the existence of primal meshes, dual meshes, and differing interpolation methods, there are a total of eight different discrete flat operators. One example is the $♭_{dpp}$  operator, or the dual-primal-primal operator. This operator inputs discrete dual vector fields, uses dual-primal interpolation, and outputs cochains on the primal mesh. For non-flat meshes, operators that input dual vector fields are more applicable than ones that do not. This operator is represented as a sparse mesh.
 
 ### Important Properties
 
+$ \flat: \mathfrak{X}\_d(K) \rightarrow \Omega^1\_d(K) $
+
+The discrete flat operator maps discrete vector fields (usually tangent vectors at primal vertices or circumcenters/barycenters) on mesh K to discrete 1-forms on K.
+
 $ ⟨X, v⟩ = X^♭ (v)$
 
-The formula defines displays the flat operator in the smooth case. The inner product of a vector field X with a second vector field v is equivalent to the inner product $ X^♭ (v) = \langle \rangle $ at every point of the Riemannian manifold M with metric $ \langle \rangle $.
+The formula defines the flat operator in the smooth case. The inner product of a vector field X with a second vector field v is equivalent to the inner product $ X^♭ (v) = \langle \rangle $ at every point of the Riemannian manifold M. The metric is defined with $ \langle \rangle $.
 
-$ \langle X^{\flat_{dpp}}, \sigma^1 \rangle =
-\sum_{\sigma^n \succ \sigma^1} \frac{\star \sigma^1 \cap \sigma^n |}{| \star \sigma^1 |}
+$ \langle X^{\flat\_{dpp}}, \sigma^1 \rangle =
+\sum_{\sigma^n \succ \sigma^1} \frac{| \star \sigma^1 \cap \sigma^n |}{| \star \sigma^1 |}
 X(\sigma^n)\cdot \tilde{\sigma^1}
 $
 
-The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge $(∑_{σ^n≻ σ^1} )$, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell $( |∗σ^1 ∩ σ^n |/|∗ σ^1 | )$. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge $(X(\sigma^n) \cdot \tilde{\sigma^1})$. Finally, sum all contributions.
+The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge $(∑_{σ^n≻ σ^1} )$, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell $( |\star σ^1 ∩ σ^n |/|\star σ^1 | )$. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge $(X(\sigma^n) \cdot \tilde{\sigma^1})$. Finally, sum all contributions.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 5.3-5.6 (pp. 46-54)
 
-Discrete Exterior Calculus - Desbrun et. al.
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 7 (p. 16)
 
-Notes on Discrete Exterior Calculus - Gillette 
+Notes on Discrete Exterior Calculus - Gillette\
 Section 2.12 (pp. 14-15)
 
 ## Sharp
@@ -482,18 +478,20 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     get_orthogonal_vector(s::AbstractDeltaDualComplex2D, v::Int, e::Int)
     ♭♯(s::HasDeltaSet2D, α::SimplexForm{1})
     ♭♯_mat(s::HasDeltaSet2D)
-    
-CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The sharp operator is a musical isomorphism that linearly maps 1-forms to vector fields. In the smooth case, it is the inverse of the flat operator. In the discrete case, it has no exact inverse. It is used as a component in the interior product and Lie Derivative operators.
+The sharp operator is a musical isomorphism that linearly maps 1-forms to vector fields. In the smooth case, it is the inverse of the flat operator. In the discrete case, it has no exact inverse. It is used as a component in the interior product and Lie derivative operators.
 
-As the smooth definition of the sharp operator is reliant on the inner product, it is a metric operator. There are a total of four different discrete sharp operators to account for form inputs and vector outputs on the primal and dual meshes. It is represented as a sparse mesh. 
+As the smooth definition of the sharp is reliant on a metric, the sharp is a metric-dependent operator. There are a total of four different discrete sharp operators to account for form inputs and vector outputs on the primal and dual meshes. It is represented as a sparse matrix. 
 
 The sharp vector turns k-forms into k-vectors. In the smooth case, it is inverses with the flat operator. The discrete sharp operator(s) lack this inverse.
 
 ### Important Properties
+
+$ \sharp: \Omega^1\_d(K) \rightarrow \mathfrak{X}\_d(K) $
+
+The discrete sharp operator maps discrete 1-forms on mesh K to discrete vector fields on mesh K. The vectors are usually tangent to primal vertices or mesh circumcenters/barycenters. 
 
 $ ⟨ω^{\sharp}, v⟩ = ω(v) $
 
@@ -501,10 +499,10 @@ The formula defines the sharp operator map in the smooth case. The inner product
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Chapter 5.7-5.8 (pp. 54-56)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 7 (p. 16)
 
 ## Codifferential
@@ -526,31 +524,27 @@ CombinatorialSpaces.jl, DiscreteExteriorCalculus.jl
     δ(::Type{Val{n}}, s::HasDeltaSet, ::GeometricHodge, matrix_type) where n
     δ(::Type{Val{n}}, s::HasDeltaSet, ::GeometricHodge, form::AbstractVector) where n
 
-CombinatorialSpaces.jl, FastDEC.jl
-
 ### Description
 
-The codifferential operator serves as the adjoint of the exterior derivative. It maps k-forms to (k-1)-forms. This operator is used to represent divergence and as a component of the Laplace-Beltrami (Laplacian) operator.
+The codifferential operator acts as the adjoint of the exterior derivative. It linearly maps k-forms to (k-1)-forms. This operator can represent divergence and it is used in the algebraic definition of the Laplacian operator.
 
-This operator is metric due to the reliance of the hodge star in its definition. It is represented as a sparse matrix created by combining hodge star and exterior derivative matrices and accounting for orientation. 
+This operator is metric due to the reliance of the hodge star in its definition. It is represented as a sparse matrix created by combining hodge star and exterior derivative matrices. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation.
 
-In the smooth setting, the codifferential is the adjoint of the exterior derivative operator. This property is retained in the discrete setting as well. It is defined through hodge star and exterior derivative operators. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation. This operator is also used as a part of the algebraic definition for the Laplace-Beltrami operator. 
-
-Finally, due to the presence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. Due to inaccuracies in the discrete hodge star, the discrete codifferential applied twice is approximately zero.
+Finally, due to the presence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. However, due to inaccuracies in the discrete hodge star, the discrete codifferential applied twice is only approximately zero.
 
 ### Important Properties
 
-$ \Omega_d^{k+1} (K) \rightarrow \Omega_d^k (K) $
+$ \delta^k: \Omega\_d^{k+1} (K) \rightarrow \Omega\_d^k (K) $
 
-The discrete codifferential operator is a linear map that inputs discrete (k+1)-forms on mesh K and outputs discrete k-forms.
+The discrete codifferential operator is a linear map that inputs discrete (k+1)-forms on mesh K and outputs discrete k-forms on K.
 
 $ δf = 0 $
 
 The formula above shows that the codifferential of a 0-form f is equal to zero. The codifferential operator takes a k-form and outputs a (k-1)-form. There is no such thing as a (-1)-form, so the operation outputs zero.
 
-$ δω = (−1)^{n(k−1)+1} ⋆ d ⋆ ω $
+$ δω = (−1)^{n(k−1)+1} * d * ω $
 
-The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  decides the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
+The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  represents the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
 
 $ ⟨dω, β⟩ = ⟨ω, δβ⟩ $
 
@@ -558,13 +552,13 @@ The exterior derivative and codifferential are adjoint in both the smooth and di
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 4.2 (p. 42)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 6 (p. 15)
 
-Discrete Differential Forms for Computational Modeling - Desbrun et. al.   
+Discrete Differential Forms for Computational Modeling - Desbrun et. al.\
 Section 5.5
 
 ## Interior Product
@@ -593,42 +587,42 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The interior product contracts a vector field with a k-form, outputting a (k-1)-form. It is an operator that "combines" forms and vector fields together by plugging in the field into one of the form's inputs. In differential geometry, forms are measurement tools that input vectors and output scalar values. The interior product makes use of this definition to merge vector fields and forms together.
+The interior product contracts a vector field with a k-form, outputting a (k-1)-form. It is an operator that "combines" forms and vector fields together by plugging in the field into one of the form's inputs. In exterior algebra, forms are measurement tools that input vectors and output scalar values. The interior product makes use of this definition to merge vector fields and forms together.
 
 In the smooth setting, it is a topological operator. However, using the algebraic definition, this tool becomes metric due to its reliance on the flat and hodge star operators.
 
-Due to the use of the wedge product in its definition, the Leibniz Property for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie Derivative, which faces this limitation as well. 
+Due to the use of the wedge product in its definition, the Leibniz Property for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie derivative, which faces this limitation as well. 
 
-Hirani notes the existence of an extrusion definition for this operator which is not covered in this description. 
+Hirani notes the existence of an extrusion definition for this operator which is not covered in this description. However, it should be known that algebraic contraction is dual to the idea of extrusion in a geometric setting.
 
 ### Important Properties
 
-$ \Omega^k (M) \rightarrow \Omega^{k-1} (M) $
+$ i\_X: \Omega^k\_d (K) \rightarrow \Omega^{k-1}\_d (K) $
 
-The smooth interior product operator $ i_X $ maps k-forms on smooth manifold M to (k-1)-forms on M depending on vector field X. 
+The discrete interior product operator $ i_X $ maps k-forms on discrete mesh K to (k-1)-forms on K, where X is a vector field.
 
-$ i_X ω(X_1, …, X_k )=ω(X, X_1. …, X_k ) $
+$ i\_X ω(X\_1, …, X\_k ) = ω(X, X\_1. …, X\_k ) $
 
 The above definition shows the algebraic definition of the interior product. This operator contracts a vector field with a k-form, "inserting" itself into one of the slots of the form. The output is a (k-1)-form.
 
-$ i_X ω=(−1)^k(n−k) ⋆(⋆ω∧X^♭ ) $
+$ i_X ω = (−1)^k(n−k) *(*ω∧X^♭ ) $
 
-The above identity displays the interior product operator composed of hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The wedge product, hodge star, and flat operations $(⋆ω∧X^{\flat})$ represents inserting the contribution of vector field X into the form ω. The exterior hodge star returns the result to its proper dimension, k+1. Finally, the $(−1)^k(n−k)$ accounts for changes in orientation due to the hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Property for contraction will only apply to closed forms (where $dω=0$), as the discrete wedge product is only associative on closed forms.
+The above identity displays the definition of the interior product operator composed of hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The wedge product, hodge star, and flat operations $(*ω∧X^{\flat})$ represents inserting the contribution of vector field X into the form ω. The exterior hodge star returns the result to its proper dimension, k+1. Finally, the $(−1)^k(n−k)$ accounts for changes in orientation due to the hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Property for contraction will only apply to closed forms (where $dω=0$), as the discrete wedge product is only associative on closed forms.
 
 $ i_X (f) = 0 $
 
 The interior product of a 0-form f with a vector field X is always zero.
 
-$ i_X (ω^k ∧ β^l )=(i_X ω)∧β+(−1)^k ω∧(i_X β) $
+$ i\_X (ω^k ∧ β^l ) = (i\_X ω)∧β+(−1)^k ω∧(i\_X β) $
 
-The interior product follows the Leibniz Rule. For non-closed forms, it is important to note that the discrete wedge product is not associative and thus errors in this rule may appear.
+The interior product operator follows the Leibniz Rule. For non-closed forms, it is important to note that the discrete wedge product is not associative and thus errors in this rule may appear.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 8.2-8.3 (pp. 79-83)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 10 (pp. 24-26)
 
 ## Lie Derivative
@@ -656,9 +650,9 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The Lie Derivative operator inputs a k-form and outputs a k-form representing the rate of change of the form as it moves in the direction of a vector field. It is analogous to the directional derivative in vector calculus. A common application for the lie derivative is the formula for advection. 
+The Lie Derivative operator inputs a k-form and outputs a k-form representing the rate of change of the form as it moves in the direction of a vector field. It is analogous to the directional derivative in vector calculus. A common application for the Lie derivative is the formula for advection. 
 
-The Lie Derivative's algebraic definition is displayed in Cartan's Magic Formula, which uses exterior derivative and interior product operators. This smooth formula is used to define the discrete primal-dual lie derivative, where X is a discrete vector field on the primal mesh and ω is a dual k-form.
+The Lie derivative's algebraic definition is displayed in Cartan's Magic Formula, which uses exterior derivative and interior product operators. This smooth formula is used to define the discrete primal-dual lie derivative, where X is a discrete vector field on the primal mesh and ω is a dual k-form.
 
 However, this method may not satisfy the Leibniz Property of Lie Derivatives, as it uses the discrete wedge product operator (within the interior product operator). This operator is only associative on closed forms. 
 
@@ -666,25 +660,25 @@ Hirani notes an alternative flow-out definition in Section 8.5 in his thesis, Di
 
 ### Important Properties
 
-$ \Omega^k (M) \rightarrow \Omega^k (M) $
+$ \mathcal{L}\_X: \Omega^k\_d (K) \rightarrow \Omega^k\_d (K) $
 
-The smooth lie derivative $ L_X $ maps k-forms on smooth manifold M to k-forms on M depending on vector field X.
+The discrete Lie derivative $ \mathcal{L}_X $ maps k-forms on discrete mesh K to k-forms on K, where X is a vector field.
 
-$ L_X ω = i_X (dω) + d(i_X ω) $
+$ \mathcal{L}\_X ω = i\_X (dω) + d(i\_X ω) $
 
-This formula displays Cartan's Magic Formula, or an algebraic definition of the lie derivative using the interior product and the exterior derivative operators. This formula helps define the discrete primal-dual lie derivative operator on a simplicial complex. X is a discrete primal vector field and ω is a dual p-form.
+This formula displays Cartan's Magic Formula, or an algebraic definition of the Lie derivative using the interior product and the exterior derivative operators. This formula helps define the discrete primal-dual Lie derivative operator on a simplicial complex. X is a discrete primal vector field and ω is a dual p-form.
 
 
-$L_X (ω∧β)=L_X (ω)∧β+ω∧L_X (β)$
+$ \mathcal{L}\_X (ω ∧ β) = \mathcal{L}\_X (ω) ∧ β + ω ∧ \mathcal{L}\_X (β) $
 
-This is the Leibniz Property of the lie derivative, which displays the lie derivative's relationship with wedge product in the smooth case. In the discrete case, if the algebraic definition of the interior product is used, this relationship might not always be correct. This is because the algebraic interior product is defined using the wedge product. As the wedge product is only associative on closed forms (in the discrete setting), there may be errors in this Leibniz property.
+This is the Leibniz Property of the Lie derivative, which displays the Lie derivative's relationship with wedge product in the smooth case. In the discrete case, if the algebraic definition of the interior product is used, this relationship might not always be correct. This is because the algebraic interior product is defined using the wedge product. As the wedge product is only associative on closed forms (in the discrete setting), there may be errors in this Leibniz property.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 8.4-8.5 (pp. 83-85)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 10 (pp. 25-26)
 
 ## Laplacian Operator
@@ -728,7 +722,7 @@ CombinatorialSpaces.jl, FastDEC.jl
 
 ### Description
 
-The Laplacian operator, or the Laplace-Beltrami operator on 0-forms, generalizes the traditional Laplacian onto curved surfaces. It linearly maps k-forms to k-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the functions surrounding it. A positive Laplacian implies that the point is less than the surrounding average (or convex down), while a negative one implies the point is greater than the surrounding average (or convex up).
+The Laplacian operator, or the Laplace-Beltrami operator on 0-forms, generalizes the traditional Laplacian onto curved surfaces. It linearly maps k-forms to k-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the points surrounding it. A positive Laplacian implies that the point is less than the surrounding average (or concave up), while a negative one implies the point is greater than the surrounding average (or concave up).
 
 This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies from $ \Delta = \delta d + d \delta $ to $ δd $, as the codifferential of a 0-form is always zero.
 
@@ -736,22 +730,22 @@ It is represented as a sparse matrix. Due to its reliance on the codifferential 
 
 ### Important Properties
 
-$ \Omega^k (M) \rightarrow \Omega^k (M) $
+$ \Delta^k:\Omega^k\_d (K) \rightarrow \Omega^k\_d (K) $
 
-The smooth Laplace-deRham operator, the general form of the Laplace-Beltrami, maps k-forms on smooth manifold M to k-forms on the same manifold.
+The discrete Laplace-deRham operator, the general form of the Laplace-Beltrami, maps k-forms on discrete mesh K to k-forms on the same mesh.
 
 $ Δ = dδ + δd $
 
-This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $∇f=δdf$, is a special situation for 0-form functions, where $ d(δf) = 0$ as the codifferential of a 0-form is always zero.
+This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $ \Delta f=δdf $, is a special situation for 0-form functions where $ d(δf) = 0$ as the codifferential of a 0-form is always zero.
 
-$ ⟨Δf, σ^0 ⟩ = \frac{1}{ |\sigma_o| }  ∑_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
+$ ⟨Δf, σ^0 ⟩ = \frac{1}{ |\sigma\_o| }  ∑\_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
 
-This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex $σ^0$,  $(⟨Δf, σ^0 ⟩)$ can be evaluated by the sum/contribution of all edges bordering $σ^0$, each weighted by the length of their corresponding dual edge divded by their primal length $(|⋆σ^1 |/|σ^1 | )$, and then multiplied by the difference between the form at the evaluated vertex $(f(σ^0))$ and the neighboring vertex $(f(v))$, connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell $(1/|⋆σ^0 | )$ to normalize it. This formula matches with another geometric Laplace-Beltrami formula that uses cotangents and indices.
+This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex $σ^0$,  $(⟨Δf, σ^0 ⟩)$ can be evaluated by the sum/contribution of all edges bordering $σ^0$, each weighted by the length of their corresponding dual edge divded by their primal length $(|⋆σ^1 |/|σ^1 | )$, and then multiplied by the difference between the form at the evaluated vertex $(f(σ^0))$ and the neighboring vertex $(f(v))$, connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell $(1/|⋆σ^0 | )$ to normalize it. This formula was found to be equivalent with a different geometric Laplace-Beltrami formula that uses cotangents and indices.
 
 ### Citations
 
-Discrete Exterior Calculus - Hirani  
+Discrete Exterior Calculus - Hirani\
 Section 6.4 (pp. 68-70)
 
-Discrete Exterior Calculus - Desbrun et. al.  
+Discrete Exterior Calculus - Desbrun et. al.\
 Section 10 (pp. 26-27)

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -1,0 +1,43 @@
+# Discrete Exterior Calculus Operator Table
+
+Preface: This document is meant to be 
+The reader can find more rigorous definitions in the referenced sources for each operator.
+
+## Boundary
+
+### Description
+
+Topological/Metric: Topological
+
+### Algorithmic Properties
+
+∂(∂c)=0 
+
+The formula above displays the property that the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to chains/simplices as well.
+
+⟨dω, c⟩ = ⟨ω, ∂c⟩
+
+The boundary operator is dual to the exterior derivative. In fact, the exterior derivative can be called the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the interior product of a chain and a cochain is synonymous to evaluating the cochain on the chain, requiring neither a metric nor a dot product. It is also the discrete analogue of integrating a form over a region.
+
+### Citations
+
+Notes on Discrete Exterior Calculus
+Page 10
+
+Discrete Exterior Calculus
+Section 4.1 (pp. 40-41)
+
+
+
+
+
+- Heelllllooooo
+- Goooodbyeeee
+
+1) Hello
+2) Hello
+3) 000
+4) Goodbye
+
+$$ \sigma^1 \sum_{12} $$
+

--- a/docs/src/dec_operator_table.md
+++ b/docs/src/dec_operator_table.md
@@ -1,6 +1,6 @@
 # Discrete Exterior Calculus Operator Table
 
-This document is meant to provide simplified descriptions of the operators of discrete exterior calculus (DEC). The reader can find more rigorous definitions in the referenced sources for each operator. The links to the sources referenced for the operators are at the bottom of the document.
+This document provides simplified descriptions of the operators of discrete exterior calculus (DEC). More rigorous definitions can be found in the cited sources for each operator. Links to those sources appear at the bottom of the document.
 
 ## Boundary
 
@@ -19,33 +19,49 @@ This document is meant to provide simplified descriptions of the operators of di
 
 ### Description
 
-The boundary operator acts on the geometry of the mesh, linearly mapping k-chains to (k-1)-chains. It relates to the important exterior derivative operator via duality, and helps compute the operator through Generalized Stokes' Theorem.
+The boundary operator acts on the geometry of the mesh, linearly mapping ``k``-chains to ``(k-1)``-chains. It relates to the exterior derivative operator via duality and helps compute that operator through [Generalized Stokes' Theorem](https://en.wikipedia.org/wiki/Generalized_Stokes_theorem).
 
-This operator inputs k-chains and outputs (k-1)-chains (or k-manifolds to (k-1)-manifolds in the smooth case). For example, it could map a 1-chain, representing a line, to the two endpoints of that line. This operator has nilpotency, meaning the boundary operator applied to the same geometry is always zero. This property is important in the exterior derivative for preserving geometric invariants and physical conservation laws. 
+This operator inputs ``k``-chains and outputs ``(k-1)``-chains (or ``k``-manifolds to ``(k-1)``-manifolds in the smooth case). For example, it could map a 1-chain, representing a line, to the two endpoints of that line. This operator is nilpotent, meaning that applying the boundary operator twice to the same geometry always gives zero. This property is important in the exterior derivative for preserving geometric invariants and physical conservation laws.
 
-This operator is computed by comparing the orientation of the k-chain with its respective (k-1)-chain boundary. It is represented as a matrix with dimensions $|C_{k−1} |×|C_k |$. It inputs a k-chain and outputs a (k-1)-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective k-chain. This computation only needs local information involving the k-chain and the simplexes within/around it. The computation of this operator is local, topological, and coordinate-free.
+This operator is computed by comparing the orientation of the ``k``-chain with its respective ``(k-1)``-chain boundary. It is represented as a matrix with dimensions ``|C_{k-1}| \times |C_k|``. It inputs a ``k``-chain and outputs a ``(k-1)``-chain, as explained before. This matrix is sparse with elements of either 0, +1, or -1, depending on boundary relations with their respective ``k``-chain. This computation only needs local information involving the ``k``-chain and the simplices incident to it. The computation of this operator is local, topological, and coordinate-free.
 
-This tool is important in defining the exterior derivative operator through Generalized Stokes' Theorem. This theorem states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. Using this definition and the boundary operator's duality, the exterior derivative is the transpose of the boundary matrix. 
+The boundary operator is important in defining the exterior derivative operator through Generalized Stokes' Theorem. This theorem states that integrating the exterior derivative of a form over a manifold is equivalent to integrating the form over the boundary of that manifold. Using this duality, the discrete exterior derivative is represented by the transpose of the boundary matrix.
 
-Finally, this operator is natural with respect to discrete pullbacks. This statement means that applying the boundary to simplex X before mapping a form on X to Y is the same as mapping the form on X to Y and then applying the operator to Y. This trait preserves the structure of the mesh under situations like mesh refinement and mesh deformations.
+Finally, this operator is natural with respect to discrete pullbacks. This means that applying the boundary to a simplex in ``X`` before applying a chain map from ``X`` to ``Y`` gives the same result as first applying the chain map and then taking the boundary of the mapped simplex. This property preserves the mesh structure under operations such as mesh refinement and mesh deformations.
+
+```math
+\begin{array}{ccc}
+C_k(X) & \xrightarrow{f_\#} & C_k(Y) \\
+\downarrow\scriptstyle{\partial_X} & & \downarrow\scriptstyle{\partial_Y} \\
+C_{k-1}(X) & \xrightarrow{f_\#} & C_{k-1}(Y)
+\end{array}
+```
 
 ### Important Properties
 
-$ \partial^k: Cₖ(K; ℤ) → Cₖ₋₁(K; ℤ) $  
+```math
+\partial^k: C_k(K; \mathbb{Z}) \to C_{k-1}(K; \mathbb{Z})
+```
 
-The boundary operator linearly inputs linear combinations of k-chains (integers with respect to simplex orientation, represented by $ \Z $) on mesh K and outputs the combined (k-1)-chain sum of the boundary of those k-chains.  
+The boundary operator linearly inputs linear combinations of ``k``-chains (integers with respect to simplex orientation, represented by ``\mathbb{Z}``) on mesh ``K`` and outputs the combined ``(k-1)``-chain sum of the boundary of those ``k``-chains.
 
-$ ∂(∂c) = 0 $
+```math
+\partial(\partial c) = 0
+```
 
 The formula above displays the property of nilpotency for the boundary operator. In other words, the boundary of a boundary is always zero. For example, the boundary of a line is its two endpoints, and the boundary of points is zero. The boundary of a ball is a hollow sphere, and the boundary of a hollow sphere is zero. This property applies to chains as well.
 
-$ ⟨dω, c⟩ = ⟨ω, ∂c⟩ $
+```math
+\langle d\omega, c \rangle = \langle \omega, \partial c \rangle
+```
 
-The boundary operator is dual to the exterior derivative. In fact, the exterior derivative is defined as the coboundary operator. In other words, the exterior derivative of a form dω applied to the chain c is equivalent to the regular form ω applied to the boundary of that chain ∂c. This property is described in Generalized Stokes' Theorem and helps in the calculation of the exterior derivative. Consider ⟨ ⟩  to be brackets representing the inner product, where the inner product of a chain and a cochain is synonymous to integrating the cochain on the chain, not requiring a metric. It is also the discrete analogue of integrating a form over a region.
+The boundary operator is dual to the exterior derivative. In fact, the exterior derivative is defined as the coboundary operator. In other words, evaluating the exterior derivative ``d\omega`` on the chain ``c`` is equivalent to evaluating ``\omega`` on the boundary ``\partial c``. This relationship is captured by Generalized Stokes' Theorem and helps define the exterior derivative. In this case, ``\langle \cdot, \cdot \rangle`` denotes a chain-cochain pairing, which can be interpreted as integrating a cochain over a chain.
 
-$ ∂[v₀, v₁, …, vₖ] = ∑ᵏᵢ₌₀ (−1)ⁱ [v₀, …, v̂ᵢ, …, vₖ] $  
+```math
+\partial [v_0, v_1, \ldots, v_k] = \sum_{i=0}^{k} (-1)^i [v_0, \ldots, \hat{v}_i, \ldots, v_k]
+```
 
-The formula above displays how the boundary operator is computed/defined in the discrete setting. The operator inputs a chain with a particular ordering of vertices, where edges may look like $e=[v_0, v_1]$ and faces may look like $σ=[v_0, v_1, v_2]$. Let's assume the operator inputs the triangular face $σ_o=[v_0, v_1, v_2]$ surrounded by the edges $e_0=[v_0, v_1]$, $e_1=[v_1, v_2]$, and $e_2=[v_o, v_2]$. The boundary operator omits the i-th vertex of the face for each iteration. The operation determines the sign of this edge based on if 'i' is even or odd. For this face $σ_o$, the result $∂[v_o, v_1, v_2 ]=[v_1, v_2 ]−[v_o, v_2 ]+[v_o, v_1 ]=e_1−e_2+e_o$. If the reader creates a visual representation of the face and surrounding vertices, with orientations going from the first vertex and moving to the last, the result will be the same.
+The formula above displays how the boundary operator is computed in the discrete setting. The operator inputs a chain with a particular ordering of vertices, where edges may look like ``e = [v_0, v_1]`` and faces may look like ``\sigma = [v_0, v_1, v_2]``. Suppose the operator inputs the triangular face ``\sigma_0 = [v_0, v_1, v_2]`` surrounded by the edges ``e_0 = [v_0, v_1]``, ``e_1 = [v_1, v_2]``, and ``e_2 = [v_0, v_2]``. The boundary operator omits the ``i``-th vertex of the face at each step. The sign of each term is determined by whether ``i`` is even or odd. For this face ``\sigma_0``, the result is ``\partial [v_0, v_1, v_2] = [v_1, v_2] - [v_0, v_2] + [v_0, v_1] = e_1 - e_2 + e_0``. A sketch of the face with consistent edge orientations reproduces the same result.
 
 ### Citations
 
@@ -59,18 +75,16 @@ Notes on Discrete Exterior Calculus - Gillette\
 Section 2.6 (p. 10)
 
 Discrete Differential Forms for Computational Modeling - Desbrun et. al.\
-Section 3 
+Section 3
 
 ## Exterior Derivative
 
 ### Signature
 
 #### Decapodes.jl
-    
+
     :d₀ => dec_differential(0, sd) |> matmul
     :d₁ => dec_differential(1, sd) |> matmul
-    :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
-    :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
     :dual_d₀ || :d̃₀ => dec_dual_derivative(0, sd) |> matmul
     :dual_d₁ || :d̃₁ => dec_dual_derivative(1, sd) |> matmul
 
@@ -93,45 +107,57 @@ Section 3
 
 ### Description
 
-The exterior derivative operator extends the idea of differentiation into differential geometry. It generalizes vector calculus concepts such as gradient, divergence, and curl onto multidimensional forms. It is a requirement for modeling any partial differential equation in an exterior calculus framework.
+The exterior derivative operator extends the idea of differentiation into differential geometry. It generalizes vector calculus concepts such as gradient, divergence, and curl to differential forms of various degrees. It is a central operator in many partial differential equations represented in the exterior calculus framework.
 
-This operator linearly maps k-forms to (k+1)-forms (or k-cochains to (k+1)-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the exterior derivative operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. This operator on a 3-form in 3D space is always zero.
+This operator linearly maps ``k``-forms to ``(k+1)``-forms (or ``k``-cochains to ``(k+1)``-cochains in the discrete setting), representing the form's rate of change on the mesh. In 3D space, the exterior derivative operator represents the gradient on a 0-form, the curl on a 1-form, and divergence on a 2-form. Applied to a 3-form in 3D space, this operator is always zero.
 
-This operator matrix is calculated with Generalized Stokes' Theorem, which states that the exterior derivative of a form integrated/evaluated over a manifold is equivalent to the form integrated over the boundary of that manifold. In the discrete setting, the exterior derivative for a cochain is the transpose of the boundary matrix operator for its respective chain. Like the boundary operator, it is a sparse matrix with elements 0, +1, and -1. The computation of this operator is local, topological, and coordinate-free.
+In the discrete setting, this operator matrix is determined by Generalized Stokes' Theorem, which states that integrating the exterior derivative of a form over a manifold is equivalent to integrating the form over the boundary of that manifold. Accordingly, the exterior derivative for a cochain is the transpose of the boundary matrix for the corresponding chain complex. Like the boundary operator, it is a sparse matrix with entries 0, +1, and -1. The computation of this operator is local, topological, and coordinate-free.
 
-This operator determines the dimensional rate of change of a form based on the values of the forms around it. For example, imagine three cochains attached to 1-simplexes (lines) that form a triangle. The exterior derivative of the 1-cochain formed from the three values is a 2-cochain residing on the triangular face, calculated by adding or subtracting the cochains together depending on face and edge orientations. 
+This operator determines the dimensional rate of change of a form based on the values of nearby forms. For example, imagine three cochains attached to 1-simplices that form a triangle. The exterior derivative of the resulting 1-cochain is a 2-cochain residing on the triangular face, computed by adding or subtracting the cochain values according to face and edge orientations.
 
-Furthermore, the exterior derivative shares the property of nilpotency with its dual operator. Thus, the exterior derivative applied twice to the same form is always zero. This trait ingrains geometrical information and mathematical conservation properties, such as the curl of a form's divergence always being zero. 
+Furthermore, the exterior derivative is nilpotent, meaning that applying it twice to the same form always gives zero, or ``d^2 = 0``. This property preserves geometric structure and mathematical conservation laws. For example, it encodes identities such as the fact that the divergence of a curl is zero and that the curl of a gradient is zero.
 
-On a dual mesh, the discrete exterior derivative may change in sign to account for the mesh's differing orientation. This formula is displayed in the Important Properties section.
+On a dual mesh, the discrete exterior derivative may change sign to account for the mesh's differing orientation. This correction appears in the Important Properties section.
 
-Finally, this operator is natural with respect to discrete pullbacks, like the boundary. It also has an adjoint with the codifferential operator, allowing for Hodge Decompositions and the Laplacian.
+Finally, this operator is natural with respect to discrete pullbacks, like the boundary.
 
 ### Important Properties
 
-$ d^k: \Omega\_{d}^k (K) \rightarrow \Omega\_{d}^{k + 1} (K) $
+```math
+d^k: \Omega_d^k(K) \to \Omega_d^{k+1}(K)
+```
 
-The discrete exterior derivative linearly maps discrete k-forms on mesh K to discrete (k+1)-forms on mesh K.
+The discrete exterior derivative linearly maps discrete ``k``-forms on mesh ``K`` to discrete ``(k+1)``-forms on mesh ``K``.
 
-$ d(dω)=0 $
+```math
+d(d\omega) = 0
+```
 
-The exterior derivative applied twice to the same form is always zero. This property retains the PDE's mathematical structure (geometric invariants, $∇×∇f=0$, and $∇ ⋅∇×f=0$) without requiring any additional features. 
+The exterior derivative applied twice to the same form is always zero. This property retains the PDE's mathematical structure (geometric invariants, ``\nabla \times \nabla f = 0``, and ``\nabla \cdot \nabla \times f = 0``) without requiring any additional features.
 
-$ d(ω∧β) = dω ∧ β + (−1)^{deg⁡(ω)} ω ∧ β $
+```math
+d(\omega \wedge \beta) = d\omega \wedge \beta + (-1)^{\deg(\omega)} \omega \wedge d\beta
+```
 
-The formula above displays the Leibniz Product Rule of exterior derivatives. The operator has a product-rule-like relationship with the wedge product.
+The formula above displays the Leibniz Product Rule for the exterior derivative. The operator has a product-rule-like relationship with the wedge product.
 
-$ d = ∂^T $
+```math
+d = \partial^T
+```
 
-In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs k-forms and outputs the exterior derivative values of (k+1)-forms.
+In the discrete setting, the exterior derivative matrix is computed as the transpose of the boundary operator. It inputs ``k``-forms and outputs the exterior derivative values of ``(k+1)``-forms.
 
-$ \tilde{d}\_{n−k} = (−1)^k (d\_{k−1} )^T $ 
+```math
+\widetilde{d}_{n-k} = (-1)^k (d_{k-1})^T
+```
 
-Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction, where $ \tilde{d} $ represents the dual exterior derivative operator.
+Due to the orientation changes in dual meshes, the exterior derivative applied to dual forms must be altered to account for differing orientation and orthogonality. The formula above displays this correction, where ``\widetilde{d}`` represents the dual exterior derivative operator.
 
-$ \int \_{\Omega} d\omega = \int \_{\partial\Omega}\omega $ 
+```math
+\int_{\Omega} d\omega = \int_{\partial \Omega} \omega
+```
 
-The formula above is Generalized Stokes' Theorem. It states that a person can determine the exterior derivative of a form across a manifold by determining the value of that across the boundary of the manifold. Thus, the exterior derivative generalizes the gradient, divergence, and the curl while Generalized Stokes' Theorem generalizes Stokes' Theorem, Green's Theorem, and the Divergence Theorem into one expression.
+The formula above is Generalized Stokes' Theorem, which states that integrating the exterior derivative of a form over a manifold is equivalent to integrating the form over the boundary of that manifold. Thus, the exterior derivative generalizes the gradient, divergence, and curl, while Generalized Stokes' Theorem unifies Stokes' Theorem, Green's Theorem, and the Divergence Theorem into one expression.
 
 ### Citations
 
@@ -153,7 +179,7 @@ Section 4.1-4.3
 
 #### Decapodes.jl
 
-    :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)  
+    :∧₀₁ => dec_pair_wedge_product(Tuple{0,1}, sd)
     :∧₁₀ => dec_pair_wedge_product(Tuple{1,0}, sd)
     :∧₀₂ => dec_pair_wedge_product(Tuple{0,2}, sd)
     :∧₂₀ => dec_pair_wedge_product(Tuple{2,0}, sd)
@@ -203,55 +229,65 @@ Section 4.1-4.3
 
 ### Description
 
-The wedge product operator is used to "combine" a k-form and an l-form into a higher degree (k+l)-form. As an example, imagine two vector-like 1-cochains. The wedge product would be the signed area formed by dragging one of the forms across the other, like a determinant.
+The wedge product operator is used to combine a ``k``-form and an ``l``-form into a higher-degree ``(k+l)``-form. As an example, imagine two vector-like 1-cochains. Their wedge product can be interpreted as the signed area formed by the two inputs, analogous to a determinant.
 
-This operator is commutative when when either k or l are even, meaning $ \beta \wedge \omega = \omega \wedge \beta $. However, if both forms have odd degrees, then the operator is anti-commutative, meaning  $ β ∧ ω = − ω ∧ β $. It is also associative, where $ ( ω ∧ β) ∧ γ =ω ∧ ( β ∧ γ ) $. In the discrete case however, the associative property is limited to only closed forms. A closed form is a form whose exterior derivative is zero. Later operators which use this tool as a component also face this limitation.
+This operator is commutative when either ``k`` or ``l`` are even, meaning ``\beta \wedge \omega = \omega \wedge \beta``. However, if both forms have odd degrees, then the operator is anti-commutative, meaning ``\beta \wedge \omega = -\omega \wedge \beta``. It is also associative, where ``(\omega \wedge \beta) \wedge \gamma = \omega \wedge (\beta \wedge \gamma)``. In some DEC discretizations, including the one used in Decapodes, associativity is limited to closed forms. A closed form is a form whose exterior derivative is zero. Later operators that use this tool as a component also inherit this limitation.
 
-Another limitation is the wedge product's reliance on the metric. Certain operator formulas may require defined angles for calculating the result of this operator. However, other formulas may lack this limitation. Formulas that are not metric-dependent are natural with respect to discrete pullbacks.
+Another limitation is that this discrete DEC wedge construction depends on the metric. In particular, its value is computed using support-volume measurements even though the smooth wedge product itself is topological.
 
-Finally, the Leibniz Product Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas shown below. 
+Finally, the Leibniz Product Rule highlights an important relationship between the wedge product and exterior derivative. This rule is approximated using the operator formulas shown below.
 
 ### Important Properties
 
-$ \wedge:\Omega^k\_d (K) \times \Omega^l\_d (K) \rightarrow \Omega^{k + l}\_d (K) $
+```math
+\wedge : \Omega_d^k(K) \times \Omega_d^l(K) \to \Omega_d^{k+l}(K)
+```
 
-The discrete primal-primal wedge product inputs a discrete primal k-form and discrete primal l-form on mesh K and outputs a discrete (k+l)-form on mesh K. The discrete dual-dual wedge product and discrete primal-dual wedge product would be defined differently.
+The discrete primal-primal wedge product inputs a discrete primal ``k``-form and discrete primal ``l``-form on mesh ``K`` and outputs a discrete ``(k+l)``-form on mesh ``K``. The discrete dual-dual wedge product and discrete primal-dual wedge product would be defined differently.
 
-$ 
-\langle \omega^k \wedge \beta^l, \sigma^{k+l} \rangle := 
-\frac{1}{(k+l)!} 
-\sum\_{r\in S\_{k+l+1}} sign(\tau) \frac{|\sigma^{k+l} \cap \star v\_{\tau(k)}|}{|\sigma^{k+l}|} 
-\langle \omega, [v\_{\tau(0)}, ..., v\_{\tau(k)}] \rangle 
-\langle \beta, [v\_{\tau(k)}, ..., v\_{\tau(k+l)}] \rangle 
-$
+```math
+\langle \omega^k \wedge \beta^l, \sigma^{k+l} \rangle :=
+\frac{1}{(k+l)!}
+\sum_{r \in S_{k+l+1}} \operatorname{sign}(\tau) \frac{|\sigma^{k+l} \cap \star v_{\tau(k)}|}{|\sigma^{k+l}|}
+\langle \omega, [v_{\tau(0)}, \ldots, v_{\tau(k)}] \rangle
+\langle \beta, [v_{\tau(k)}, \ldots, v_{\tau(k+l)}] \rangle
+```
 
-This is the metric formulation for the discrete primal-primal wedge product operator, where ω is a is a discrete primal k-form and β is a discrete primal l-form. The LHS states that the evaluation of the wedge product of two forms on the appropriate face is equal to the RHS. The RHS states that for each permutation of the simplex $σ^{k+l}$  (where there are $(k+l+1)!$  orderings of the vertices), it finds the sign of that permutation $(sign(τ))$ and multiplies it by a geometric weight $(|σ^{k+l}∩⋆v_τ (k)| / |σ^(k+l) | )$. The weight determines the volume of the new simplex that is shared by the simplices touching the k-th vertex of the current permutation, divided by the volume of the new simplex. Finally, it multiplies this weight by the inner product of ω on a k-simplex formed from initial vertices $(⟨ω, [v_τ(0) , …, v_τ(k) ]⟩)$ and the inner product of β on a l-simplex formed from the vertices afterwards $(⟨β, [v_τ(k) , …, v_τ(k+l) ]⟩)$. The contributions from each permutation are summed together and normalized based on the forms' dimensions $(1/(k+l)!)$. As this formula relies on simplex magnitudes, it is metric.
+This is the metric formulation for the discrete primal-primal wedge product operator, where ``\omega`` is a discrete primal ``k``-form and ``\beta`` is a discrete primal ``l``-form. The left-hand side states that the evaluation of the wedge product of two forms on the appropriate face is equal to the right-hand side. The right-hand side states that for each permutation of the simplex ``\sigma^{k+l}`` (where there are ``(k+l+1)!`` orderings of the vertices), it finds the sign of that permutation, ``\operatorname{sign}(\tau)``, and multiplies it by a geometric weight, ``(|\sigma^{k+l} \cap \star v_{\tau(k)}| / |\sigma^{k+l}|)``. The weight determines the volume of the new simplex that is shared by the simplices touching the ``k``-th vertex of the current permutation, divided by the volume of the new simplex. Finally, it multiplies this weight by the evaluation of ``\omega`` on a ``k``-simplex formed from the initial vertices, ``\langle \omega, [v_{\tau(0)}, \ldots, v_{\tau(k)}] \rangle``, and the evaluation of ``\beta`` on an ``l``-simplex formed from the remaining vertices, ``\langle \beta, [v_{\tau(k)}, \ldots, v_{\tau(k+l)}] \rangle``. The contributions from each permutation are summed together and normalized by the factor ``(1/(k+l)!)``. As this formula relies on simplex magnitudes, it is metric.
 
-$ 
-\langle \omega^k \wedge \beta^l, \sigma^{k+l} \rangle := 
-\frac{1}{(k+l+1)!} 
-\sum\_{r\in S\_{k+l+1}} sign(\tau)  
-\langle \omega, [v\_{\tau(0)}, ..., v\_{\tau(k)}] \rangle 
-\langle \beta, [v\_{\tau(k)}, ..., v\_{\tau(k+l)}] \rangle 
-$
+```math
+\langle \omega^k \wedge \beta^l, \sigma^{k+l} \rangle :=
+\frac{1}{(k+l+1)!}
+\sum_{r \in S_{k+l+1}} \operatorname{sign}(\tau)
+\langle \omega, [v_{\tau(0)}, \ldots, v_{\tau(k)}] \rangle
+\langle \beta, [v_{\tau(k)}, \ldots, v_{\tau(k+l)}] \rangle
+```
 
-The formula above is the topological primal-primal wedge product operator. It follows the same trend as the metric case. However, this one does not use a geometric weighing factor, and instead accounts for weight with normalization $(1/(k+l+1)!)$. 
+The formula above is the topological primal-primal wedge product operator. It follows the same trend as the metric case. However, this one does not use a geometric weighting factor, and instead accounts for weight with the normalization ``(1/(k+l+1)!)``.
 
-$ ω^k ∧ β^l =(−1) ^ {kl}⁡(β∧ω) $
+```math
+\omega^k \wedge \beta^l = (-1)^{kl}(\beta^l \wedge \omega^k)
+```
 
-This formula displays the commutative (or anti-commutative) property of wedge product. If the inputted form degrees (k and l) are both odd, switching the order of the forms on the wedge product would swap the sign of the outputted form. This is the extension of the idea that forms are antisymmetric tensors, and swapping the forms that create a higher degree form change the orientation of the area/volume/length. However, if either l or l are even, then swapping terms in the wedge product will not affect signage.
+This formula expresses the graded-commutativity of the wedge product. If the form degrees ``k`` and ``l`` are both odd, switching the order of the forms swaps the sign of the resulting form. This reflects the fact that forms behave like antisymmetric tensors, so swapping the inputs that define a higher-degree form changes the orientation of the resulting area, volume, or higher-dimensional element. However, if either ``k`` or ``l`` is even, then swapping the terms does not change the sign.
 
-$ (ω∧β)∧γ = ω∧(β∧γ) $
+```math
+(\omega \wedge \beta) \wedge \gamma = \omega \wedge (\beta \wedge \gamma)
+```
 
 This formula displays the associative property of the wedge product operator in the smooth case. In the discrete case, this is only true for closed forms. The exterior derivative of a closed form is zero.
 
-$ d(ω∧β) = dω ∧ β+(−1)^{deg⁡(ω)} ω ∧ β $
+```math
+d(\omega \wedge \beta) = d\omega \wedge \beta + (-1)^{\deg(\omega)} \omega \wedge d\beta
+```
 
-As displayed in the exterior derivative section, the Leibniz Product Rule defines the interaction between the exterior derivative and the wedge product operators. 
+As displayed in the exterior derivative section, the Leibniz Product Rule defines the interaction between the exterior derivative and the wedge product operators.
 
-$ ω ∧ ω = 0 $
+```math
+\omega \wedge \omega = 0
+```
 
-This formula shows the alternating property of wedge product in the smooth case. Due to its antisymmetric nature, the wedge product of two equivalent, even-dimensioned forms is always zero.
+This formula shows the alternating property of the wedge product in the smooth case. Note that this vanishing property holds for odd-degree forms, by graded-commutativity.
 
 ### Citations
 
@@ -271,7 +307,7 @@ Section 8 (pp. 17-21)
     :⋆₁ => dec_hodge_star(1, sd, hodge=hodge) |> matmul
     :⋆₂ => dec_hodge_star(2, sd, hodge=hodge) |> matmul
     :⋆₀⁻¹ => dec_inv_hodge_star(0, sd, hodge) |> matmul
-    :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge)  
+    :⋆₁⁻¹ => dec_pair_inv_hodge(Val{1}, sd, hodge)
     :⋆₂⁻¹ => dec_inv_hodge_star(1, sd, hodge) |> matmul
 
 #### CombinatorialSpaces.jl
@@ -332,35 +368,39 @@ Section 8 (pp. 17-21)
 
 ### Description
 
-The Hodge star operator maps k-forms to their respective "orthogonal" (n-k)-forms based on the Riemannian metric (or inner product). 'n' is the number of dimensions in the space. It relates the primal mesh to the dual mesh. For example, in 2D space, points are outputted as areas, lines become orthogonal lines, and areas become midpoints of the space. It is also an important component in later operators.
+The Hodge star operator maps ``k``-forms to their respective "orthogonal" ``(n-k)``-forms based on the [Riemannian metric](https://en.wikipedia.org/wiki/Riemannian_metric) (or inner product). Here, ``n`` is the number of dimensions in the space. It relates the primal mesh to the dual mesh by relating a chain to a corresponding dual chain. In 2D, primal vertices correspond to dual 2-cells, primal edges correspond to transverse dual edges, and primal faces correspond to dual vertices. It is also an important component in later operators.
 
-The discrete Hodge star is computed using a formula which states that the original form evaluated on the original simplex divided by the simplex's magnitude is equivalent to the starred form evaluated on the "orthogonal" simplex divided by the "orthogonal" simplex's magnitude. This formula ensures dual and primal meshes contain the same information. The operator is also an isomorphism, meaning the Hodge star applied twice to a form will return the original form (with a potential sign change depending on dimensions). 
+The discrete Hodge star is computed using a formula that states that the original form evaluated on the original simplex, divided by the simplex's magnitude, is equivalent to the starred form evaluated on the orthogonal simplex, divided by the orthogonal simplex's magnitude. This formula ensures that the dual and primal meshes contain the same information. The operator is also an isomorphism, meaning that the Hodge star applied twice to a form returns the original form, up to a potential sign change depending on dimension.
 
-The operator matrix is calculated through either two methods - the geometric Hodge or the diagonal Hodge. The geometric Hodge is calculated as a sparse, symmetrical matrix with elements dependent on the ratio between simplex and orthogonal simplex magnitudes. It pairs well with barycentric dual mesh centering. The matrix dimensions are $|C_k |×|C_k |$. The diagonal Hodge is a diagonal matrix with the same dimensions. It is calculated faster but has less accuracy. It pairs well with circumcentric dual mesh centering.
+The operator matrix can be computed in multiple ways but namely as the geometric Hodge or the diagonal Hodge. The geometric Hodge is calculated as a sparse, symmetric matrix with entries determined by the ratio between simplex and orthogonal simplex magnitudes. It pairs well with barycentric dual mesh centering. The matrix dimensions are ``|C_k| \times |C_k|``. The diagonal Hodge is a diagonal matrix with the same dimensions. It is faster to compute but less accurate. It pairs well with circumcentric dual mesh centering.
 
-This operator is metric-dependent. It is reliant on a metric to determine angles and orthogonality. Thus, the result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on if the dual mesh is barycentric-centered or circumcentric-centered, the Hodge star may return differing results. Furthermore, stretching the mesh would cause changes in simplex magnitudes on primal and dual meshes, thus affecting the output values from the Hodge star operator.
-
-Finally, as this operator is metric-dependent, it does not commute fully with respect to natural pullbacks. However, the code attempts to approximate this property as much as possible for accurate simulations.
+This operator is metric-dependent. It depends on a metric to determine angles and orthogonality. Thus, the result of this operator may differ even if simplex connectivity, cochain values, and orientations remain the same. For example, depending on whether the dual mesh is barycentric-centered or circumcentric-centered, the Hodge star may return different results. Furthermore, stretching the mesh changes simplex magnitudes on the primal and dual meshes, which in turn affects the output values of the Hodge star operator.
 
 ### Important Properties
 
-$ *^k:\Omega^k\_d (K) \rightarrow \Omega^{n - k}\_d (\star K) $
+```math
+\star^k : \Omega_d^k(K) \to \Omega_d^{n-k}(\star K)
+```
 
-The discrete Hodge star linearly maps discrete k-forms on mesh K to discrete (n-k)-forms on dual mesh $ \star K$, where n is the number of dimensions of the space. The $ \star $ symbol acts on geometry and outputs its dual version.
+The discrete Hodge star linearly maps discrete ``k``-forms on mesh ``K`` to discrete ``(n-k)``-forms on dual mesh ``\star K``, where ``n`` is the number of dimensions of the space. The ``\star`` symbol acts on geometry and outputs its dual version.
 
-$ ⟨ω^k, β^k ⟩v = ω^k∧*β^k $
+```math
+\langle \omega^k, \beta^k \rangle \, \mathrm{vol} = \omega^k \wedge \star \beta^k
+```
 
-The formula above displays the identity of the Hodge star in the smooth case. The inner product of  two k-dimensional forms multiplied by their volume element is equal to the wedge product between the first form and the Hodge star of the second form. The volume element encodes the metric and orientation, ensuring that the LHS has the same dimensions and sign as the right-hand side. Due to this definition, it is inherently a metric-dependent operator.
+The formula above displays the defining identity of the Hodge star in the smooth case. The inner product of two ``k``-dimensional forms, multiplied by the volume form, is equal to the wedge product between the first form and the Hodge star of the second form. The volume form encodes the metric and orientation, ensuring that the left-hand side has the same dimensions and sign as the right-hand side. Due to this definition, the Hodge star is inherently metric-dependent.
 
-$ 
-\frac{1}{|⋆σ^k |}  
-⟨*ω, ⋆σ^k ⟩ ≔ 
-\frac{1}{|σ^k |}  ⟨ω, σ^k ⟩
-$
+```math
+\frac{1}{|\star \sigma^k|}
+\langle \star \omega, \star \sigma^k \rangle \coloneqq
+\frac{1}{|\sigma^k|} \langle \omega, \sigma^k \rangle
+```
 
-The formula above is the definition of the diagonal Hodge star for $1≤k≤n−1$ forms. It states that the Hodge star of a form integrated on the dual of a simplex and divided by the length of that dual simplex must be equal to the form evaluated on the primal simplex, divided by the length of that primal simplex. The dual form maintains the same physical information while transitioning to orthogonality. Forms that do not conform to the inequality have an additional term that changes sign to account for simplex orientation.
+The formula above is the definition of the diagonal Hodge star for ``1 \le k \le n-1`` forms. It states that the Hodge star of a form integrated on the dual of a simplex and divided by the length of that dual simplex must be equal to the form evaluated on the primal simplex, divided by the length of that primal simplex. The dual form maintains the same physical information while transitioning to orthogonality. Forms that do not conform to the inequality have an additional term that changes sign to account for simplex orientation.
 
-$ **ω = (−1)^k (n−k)ω $
+```math
+\star\star \omega = (-1)^{k(n-k)} \omega
+```
 
 The Hodge star operator is an isomorphism. Using the Hodge star on a form twice returns it to its original state, with a change in sign depending on dual orientation.
 
@@ -384,8 +424,8 @@ Section 5.3-5.4
 
 #### Decapodes.jl
 
-    :♭ᵈᵖ => dec_♭(sd)                    
-    :♭♯ => ♭♯_mat(sd) |> matmul          
+    :♭ᵈᵖ => dec_♭(sd)
+    :♭♯ => ♭♯_mat(sd) |> matmul
 
 #### CombinatorialSpaces.jl
 
@@ -396,29 +436,33 @@ Section 5.3-5.4
     ♭_mat(s::AbstractDeltaDualComplex2D, p2s, ::DPPFlat)
     ♭_mat(s::AbstractDeltaDualComplex2D, ::PPFlat)
 
-
 ### Description
 
-The flat operator is a musical isomorphism that linearly maps vector fields to 1-forms. In the smooth case, it is the inverse of the sharp operator. In the discrete case, it has no exact inverse. It is often used to define certain vector quantities as forms, such as fluid flow.
+The flat operator is a [musical isomorphism](https://en.wikipedia.org/wiki/Musical_isomorphism) that linearly maps vector fields to 1-forms. In the smooth case, it is the inverse of the sharp operator. In the discrete case, it has no exact inverse. It is often used to represent vector quantities, such as fluid flow, as forms.
 
-The smooth definition of the flat operator is reliant on an inner product, making the operator metric-dependent. Due to the existence of primal meshes, dual meshes, and differing interpolation methods, there are a total of eight different discrete flat operators. One example is the $♭_{dpp}$  operator, or the dual-primal-primal operator. This operator inputs discrete dual vector fields, uses dual-primal interpolation, and outputs cochains on the primal mesh. For non-flat meshes, operators that input dual vector fields are more applicable than ones that do not. This operator is represented as a sparse mesh.
+The smooth definition of the flat operator depends on an inner product, making the operator metric-dependent. Because there are primal meshes, dual meshes, and multiple interpolation methods, there are eight different discrete flat operators. One example is the ``\flat_{dpp}`` operator, or dual-primal-primal operator. This operator inputs discrete dual vector fields, uses dual-primal interpolation, and outputs cochains on the primal mesh. For non-flat meshes, operators that input dual vector fields are often more appropriate. This operator is represented as a sparse matrix.
 
 ### Important Properties
 
-$ \flat: \mathfrak{X}\_d(K) \rightarrow \Omega^1\_d(K) $
+```math
+\flat : \mathfrak{X}_d(K) \to \Omega_d^1(K)
+```
 
-The discrete flat operator maps discrete vector fields (usually tangent vectors at primal vertices or circumcenters/barycenters) on mesh K to discrete 1-forms on K.
+The discrete flat operator maps discrete vector fields, usually tangent vectors at primal vertices or circumcenters/barycenters, on mesh ``K`` to discrete 1-forms on ``K``.
 
-$ ⟨X, v⟩ = X^♭ (v)$
+```math
+X^{\flat}(\cdot) = \langle X, \cdot \rangle
+```
 
-The formula defines the flat operator in the smooth case. The inner product of a vector field X with a second vector field v is equivalent to the inner product $ X^♭ (v) = \langle \rangle $ at every point of the Riemannian manifold M. The metric is defined with $ \langle \rangle $.
+The formula defines the flat operator in the smooth case. Essentially, since ``X`` is given as a vector, the most natural way to convert it into a form is to plug it into an inner product. Note that this aligns with the use of the metric tensor to convert between vectors and forms.
 
-$ \langle X^{\flat\_{dpp}}, \sigma^1 \rangle =
-\sum_{\sigma^n \succ \sigma^1} \frac{| \star \sigma^1 \cap \sigma^n |}{| \star \sigma^1 |}
-X(\sigma^n)\cdot \tilde{\sigma^1}
-$
+```math
+\langle X^{\flat_{dpp}}, \sigma^1 \rangle =
+\sum_{\sigma^n \succ \sigma^1} \frac{|\star \sigma^1 \cap \sigma^n|}{|\star \sigma^1|}
+X(\sigma^n) \cdot \tilde{\sigma^1}
+```
 
-The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flatted vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge $(∑_{σ^n≻ σ^1} )$, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell $( |\star σ^1 ∩ σ^n |/|\star σ^1 | )$. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge $(X(\sigma^n) \cdot \tilde{\sigma^1})$. Finally, sum all contributions.
+The formula above displays the definition for the DPP flat operator, or the operator that inputs a vector field on the dual mesh, uses dual-primal interpolation, and outputs a cochain on the primal mesh. The LHS states that the flattened vector field evaluated on an edge is equivalent to the RHS. The RHS states that for every simplex that contains the evaluated edge ``(\sum_{\sigma^n \succ \sigma^1})``, determine how much of the evaluated edge's dual cell is within the simplex, find that magnitude, and then divide it by the magnitude of the edge's dual cell ``(|\star \sigma^1 \cap \sigma^n| / |\star \sigma^1|)``. Then, multiply this value by the dot product of the simplex's average vector with the unit vector of the evaluated edge ``(X(\sigma^n) \cdot \tilde{\sigma^1})``. Finally, sum all contributions.
 
 ### Citations
 
@@ -437,9 +481,9 @@ Section 2.12 (pp. 14-15)
 
 #### Decapodes.jl
 
-    :♯ᵖᵈ => dec_♯_pd(sd)                 
-    :♯ᵖᵖ => dec_♯_pp(sd)                 
-    :♯ᵈᵈ => dec_♯_dd(sd)                 
+    :♯ᵖᵈ => dec_♯_pd(sd)
+    :♯ᵖᵖ => dec_♯_pp(sd)
+    :♯ᵈᵈ => dec_♯_dd(sd)
 
 #### CombinatorialSpaces.jl
 
@@ -461,19 +505,21 @@ Section 2.12 (pp. 14-15)
 
 The sharp operator is a musical isomorphism that linearly maps 1-forms to vector fields. In the smooth case, it is the inverse of the flat operator. In the discrete case, it has no exact inverse. It is used as a component in the interior product and Lie derivative operators.
 
-As the smooth definition of the sharp is reliant on a metric, the sharp is a metric-dependent operator. There are a total of four different discrete sharp operators to account for form inputs and vector outputs on the primal and dual meshes. It is represented as a sparse matrix. 
-
-The sharp vector turns k-forms into k-vectors. In the smooth case, it is inverses with the flat operator. The discrete sharp operator(s) lack this inverse.
+Because the smooth definition of the sharp depends on a metric, the sharp is a metric-dependent operator. There are four different discrete sharp operators to account for form inputs and vector outputs on the primal and dual meshes. It is represented as a sparse matrix.
 
 ### Important Properties
 
-$ \sharp: \Omega^1\_d(K) \rightarrow \mathfrak{X}\_d(K) $
+```math
+\sharp : \Omega_d^1(K) \to \mathfrak{X}_d(K)
+```
 
-The discrete sharp operator maps discrete 1-forms on mesh K to discrete vector fields on mesh K. The vectors are usually tangent to primal vertices or mesh circumcenters/barycenters. 
+The discrete sharp operator maps discrete 1-forms on mesh ``K`` to discrete vector fields on mesh ``K``. The vectors are usually tangent to primal vertices or mesh circumcenters/barycenters.
 
-$ ⟨ω^{\sharp}, v⟩ = ω(v) $
+```math
+\langle \omega^{\sharp}, v \rangle = \omega(v)
+```
 
-The formula defines the sharp operator map in the smooth case. The inner product $\omega^{\sharp}$ with vector field v is equivalent to the output of form $ \omega $ with the input v. This should be the case for all points in Riemannian manifold M.
+The formula defines the sharp operator in the smooth case. The vector field ``\omega^{\sharp}`` is the unique vector field satisfying ``\langle \omega^{\sharp}, v \rangle = \omega(v)`` for every vector field ``v``. This relation holds at every point of a Riemannian manifold ``M``.
 
 ### Citations
 
@@ -489,7 +535,7 @@ Section 7 (p. 16)
 
 #### Decapodes.jl
 
-    :δ₁ => add_Codiff!(d, src, tgt)  
+    :δ₁ => add_Codiff!(d, src, tgt)
     :δ₂ => add_Codiff!(d, src, tgt)
 
 #### CombinatorialSpaces.jl
@@ -504,29 +550,37 @@ Section 7 (p. 16)
 
 ### Description
 
-The codifferential operator acts as the adjoint of the exterior derivative. It linearly maps k-forms to (k-1)-forms. This operator can represent divergence and it is used in the algebraic definition of the Laplacian operator.
+The codifferential operator acts as the adjoint of the exterior derivative. It linearly maps ``k``-forms to ``(k-1)``-forms. This operator can represent divergence, and it is used in the algebraic definition of the Laplacian operator.
 
-This operator is metric due to the reliance of the Hodge star in its definition. It is represented as a sparse matrix created by combining Hodge star and exterior derivative matrices. Due to its simple definition, it can be computed just by applying three matrix operators and accounting for orientation.
+This operator is metric-dependent because it is defined using the Hodge star. This matches the smooth case, where it is the ``L^2`` adjoint of the exterior derivative and therefore requires a metric. It is represented as a sparse matrix created by combining Hodge star and exterior derivative matrices. Due to its simple definition, it can be computed by applying three matrix operators and accounting for orientation.
 
-Finally, due to the presence of the exterior derivative in its definition, the smooth codifferential operator has nilpotency - the operator applied to same form twice is zero. However, due to inaccuracies in the discrete Hodge star, the discrete codifferential applied twice is only approximately zero.
+Finally, because the codifferential is defined using the exterior derivative, the smooth codifferential is nilpotent: applying it twice gives zero. However, due to inaccuracies in the discrete Hodge star, the discrete codifferential applied twice is only approximately zero.
 
 ### Important Properties
 
-$ \delta^k: \Omega\_d^{k+1} (K) \rightarrow \Omega\_d^k (K) $
+```math
+\delta^k : \Omega_d^{k+1}(K) \to \Omega_d^k(K)
+```
 
-The discrete codifferential operator is a linear map that inputs discrete (k+1)-forms on mesh K and outputs discrete k-forms on K.
+The discrete codifferential operator is a linear map that inputs discrete ``(k+1)``-forms on mesh ``K`` and outputs discrete ``k``-forms on ``K``.
 
-$ δf = 0 $
+```math
+\delta f = 0
+```
 
-The formula above shows that the codifferential of a 0-form f is equal to zero. The codifferential operator takes a k-form and outputs a (k-1)-form. There is no such thing as a (-1)-form, so the operation outputs zero.
+The formula above shows that the codifferential of a 0-form ``f`` is equal to zero. The codifferential operator takes a ``k``-form and outputs a ``(k-1)``-form. There is no such thing as a ``(-1)``-form, so the operation outputs zero.
 
-$ δω = (−1)^{n(k−1)+1} * d * ω $
+```math
+\delta \omega = (-1)^{n(k-1)+1} \star d \star \omega
+```
 
-The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through Hodge star and exterior derivative operators. The $(−1)^{n(k−1)+1}$  represents the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as $⋆ω$ would produce a dual form. 
+The formula above displays the discrete definition of the codifferential operator on forms. It can be defined purely through Hodge star and exterior derivative operators. The ``(-1)^{n(k-1)+1}`` represents the orientation of the output. It is important to realize that if the codifferential is applied to a primal form, then the dual exterior derivative formula should be used in the definition, as ``\star \omega`` would produce a dual form.
 
-$ ⟨dω, β⟩ = ⟨ω, δβ⟩ $
+```math
+\langle d\omega, \beta \rangle = \langle \omega, \delta \beta \rangle
+```
 
-The exterior derivative and codifferential are adjoint in both the smooth and discrete settings. 
+The exterior derivative and codifferential are adjoint in both the smooth and discrete settings.
 
 ### Citations
 
@@ -545,11 +599,11 @@ Section 5.5
 
 #### Decapodes.jl
 
-    :i₁ => add_Inter_Prod_1D! or add_Inter_Prod_2D!(Val{1}, ...)  
-    :i₂ => add_Inter_Prod_2D!(Val{2}, ...)                         
-    
-    :ι₁₁ => interior_product_dd(Tuple{1,1}, sd)   
-    :ι₁₂ => interior_product_dd(Tuple{1,2}, sd)   
+    :i₁ => add_Inter_Prod_1D! or add_Inter_Prod_2D!(Val{1}, ...)
+    :i₂ => add_Inter_Prod_2D!(Val{2}, ...)
+
+    :ι₁₁ => interior_product_dd(Tuple{1,1}, sd)
+    :ι₁₂ => interior_product_dd(Tuple{1,2}, sd)
 
 #### CombinatorialSpaces.jl
 
@@ -559,36 +613,45 @@ Section 5.5
     interior_product_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
     interior_product_dd(::Type{Tuple{1,2}}, s::SimplicialSets.HasDeltaSet)
 
-
 ### Description
 
-The interior product contracts a vector field with a k-form, outputting a (k-1)-form. It is an operator that "combines" forms and vector fields together by plugging in the field into one of the form's inputs. In exterior algebra, forms are measurement tools that input vectors and output scalar values. The interior product makes use of this definition to merge vector fields and forms together.
+The interior product contracts a vector field with a ``k``-form, outputting a ``(k-1)``-form. It is an operator that "combines" forms and vector fields together by plugging the field into one of the form's inputs. In exterior algebra, forms are measurement tools that input vectors and output scalar values. The interior product makes use of this definition to merge vector fields and forms together.
 
-In the smooth setting, it is a topological operator. However, using the algebraic definition, this tool becomes metric due to its reliance on the flat and Hodge star operators.
+In the smooth setting, the interior product importantly does not require a metric to be defined. However, using the algebraic definition, this tool becomes metric due to its reliance on the flat and Hodge star operators.
 
-Due to the use of the wedge product in its definition, the Leibniz Product Rule for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie derivative, which faces this limitation as well. 
+Because of the variant of the discrete DEC wedge product used in its definition, the Leibniz Product Rule for this operator only applies for closed forms due to limits in associativity. This operator is used in the Lie derivative, which faces this limitation as well.
 
 Hirani notes the existence of an extrusion definition for this operator which is not covered in this description. However, it should be known that algebraic contraction is dual to the idea of extrusion in a geometric setting.
 
 ### Important Properties
 
-$ i\_X: \Omega^k\_d (K) \rightarrow \Omega^{k-1}\_d (K) $
+```math
+i_X : \Omega_d^k(K) \to \Omega_d^{k-1}(K)
+```
 
-The discrete interior product operator $ i_X $ maps k-forms on discrete mesh K to (k-1)-forms on K, where X is a vector field.
+The discrete interior product operator ``i_X`` maps ``k``-forms on discrete mesh ``K`` to ``(k-1)``-forms on ``K``, where ``X`` is a vector field.
 
-$ i\_X ω(X\_1, …, X\_k ) = ω(X, X\_1. …, X\_k ) $
+```math
+i_X \omega(X_1, \ldots, X_{k-1}) = \omega(X, X_1, \ldots, X_{k-1})
+```
 
-The above definition shows the algebraic definition of the interior product. This operator contracts a vector field with a k-form, "inserting" itself into one of the slots of the form. The output is a (k-1)-form.
+The above definition shows the algebraic definition of the interior product. This operator contracts a vector field with a ``k``-form, inserting it into one of the slots of the form. The output is a ``(k-1)``-form.
 
-$ i\_X \omega = (-1)^{k(n-k)} * ( * \omega \wedge X^\flat ) $
+```math
+i_X \omega = (-1)^{k(n-k)} \star (\star \omega \wedge X^{\flat})
+```
 
-The above identity displays the definition of the interior product operator composed of Hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The wedge product, Hodge star, and flat operations $(*ω∧X^{\flat})$ represents inserting the contribution of vector field X into the form ω. The exterior Hodge star returns the result to its proper dimension, k+1. Finally, the $(−1)^k(n−k)$ accounts for changes in orientation due to the Hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Product Rule for contraction will only apply to closed forms (where $dω=0$), as the discrete wedge product is only associative on closed forms.
+The above identity displays the definition of the interior product operator composed of Hodge star, wedge product, and flat operators. The discrete operator can be created in the discrete setting with discrete forms of these operators. The structure of the operator, namely ``(\star \omega \wedge X^{\flat})``, represents inserting the contribution of the vector field ``X`` into the form ``\omega``. The exterior Hodge star then returns the result to its proper dimension, ``(k-1)``. Finally, the factor ``(-1)^{k(n-k)}`` accounts for changes in orientation due to the Hodge star and wedge product operators. Due to the use of the discrete wedge product in this identity, the Leibniz Product Rule for contraction only applies to closed forms, where ``d\omega = 0``, since the discrete wedge product is only associative on closed forms.
 
-$ i_X (f) = 0 $
+```math
+i_X(f) = 0
+```
 
-The interior product of a 0-form f with a vector field X is always zero.
+The interior product of a 0-form ``f`` with a vector field ``X`` is always zero.
 
-$ i\_X (ω^k ∧ β^l ) = (i\_X ω)∧β+(−1)^k ω∧(i\_X β) $
+```math
+i_X(\omega^k \wedge \beta^l) = (i_X \omega) \wedge \beta + (-1)^k \omega \wedge (i_X \beta)
+```
 
 The interior product operator follows the Leibniz Product Rule. For non-closed forms, it is important to note that the discrete wedge product is not associative and thus errors in this rule may appear.
 
@@ -606,10 +669,10 @@ Section 10 (pp. 24-26)
 
 #### Decapodes.jl
 
-    :L₀ => add_Lie_1D!(Val{0}, ...)  
-    :L₁ => add_Lie_1D!(Val{1}, ...)  
-    :L₂ => add_Lie_2D!(Val{2}, ...)  
-    :ℒ₁ => ℒ_dd(Tuple{1,1}, sd)      
+    :L₀ => add_Lie_1D!(Val{0}, ...)
+    :L₁ => add_Lie_1D!(Val{1}, ...)
+    :L₂ => add_Lie_2D!(Val{2}, ...)
+    :ℒ₁ => ℒ_dd(Tuple{1,1}, sd)
 
 #### CombinatorialSpaces.jl
 
@@ -622,26 +685,31 @@ Section 10 (pp. 24-26)
 
 ### Description
 
-The Lie Derivative operator inputs a k-form and outputs a k-form representing the rate of change of the form as it moves in the direction of a vector field. It is analogous to the directional derivative in vector calculus. A common application for the Lie derivative is the formula for advection. 
+The Lie derivative operator inputs a ``k``-form and outputs a ``k``-form representing the rate of change of the form as it moves in the direction of a vector field. It is analogous to the directional derivative in vector calculus. A common application of the Lie derivative is advection.
 
-The Lie derivative's algebraic definition is displayed in Cartan's Magic Formula, which uses exterior derivative and interior product operators. This smooth formula is used to define the discrete primal-dual lie derivative, where X is a discrete vector field on the primal mesh and ω is a dual k-form.
+The Lie derivative's algebraic definition is displayed in Cartan's Magic Formula, which uses exterior derivative and interior product operators. This smooth formula is used to define the discrete primal-dual Lie derivative, where ``X`` is a discrete vector field on the primal mesh and ``\omega`` is a dual ``k``-form.
 
-However, this method may not satisfy the Leibniz Product Rule of Lie Derivatives, as it uses the discrete wedge product operator (within the interior product operator). This operator is only associative on closed forms. 
+However, this method may not satisfy the Leibniz Product Rule for Lie derivatives, as it uses the discrete wedge product operator within the interior product operator. This wedge product is only associative on closed forms.
 
-Hirani notes an alternative flow-out definition in Section 8.5 in his thesis, Discrete Exterior Calculus, which does not suffer from this lack of associativity. However, this definition is not covered here.
+Hirani notes an alternative flow-out definition in Section 8.5 of his thesis, Discrete Exterior Calculus, which does not suffer from this lack of associativity. However, that definition is not covered here.
 
 ### Important Properties
 
-$ \mathcal{L}\_X: \Omega^k\_d (K) \rightarrow \Omega^k\_d (K) $
+```math
+\mathcal{L}_X : \Omega_d^k(K) \to \Omega_d^k(K)
+```
 
-The discrete Lie derivative $ \mathcal{L}_X $ maps k-forms on discrete mesh K to k-forms on K, where X is a vector field.
+The discrete Lie derivative ``\mathcal{L}_X`` maps ``k``-forms on discrete mesh ``K`` to ``k``-forms on ``K``, where ``X`` is a vector field.
 
-$ \mathcal{L}\_X ω = i\_X (dω) + d(i\_X ω) $
+```math
+\mathcal{L}_X \omega = i_X(d\omega) + d(i_X \omega)
+```
 
-This formula displays Cartan's Magic Formula, or an algebraic definition of the Lie derivative using the interior product and the exterior derivative operators. This formula helps define the discrete primal-dual Lie derivative operator on a simplicial complex. X is a discrete primal vector field and ω is a dual p-form.
+This formula displays Cartan's Magic Formula, or an algebraic definition of the Lie derivative using the interior product and the exterior derivative operators. This formula helps define the discrete primal-dual Lie derivative operator on a simplicial complex. Here, ``X`` is a discrete primal vector field and ``\omega`` is a dual ``p``-form.
 
-
-$ \mathcal{L}\_X (ω ∧ β) = \mathcal{L}\_X (ω) ∧ β + ω ∧ \mathcal{L}\_X (β) $
+```math
+\mathcal{L}_X(\omega \wedge \beta) = \mathcal{L}_X(\omega) \wedge \beta + \omega \wedge \mathcal{L}_X(\beta)
+```
 
 This is the Leibniz Product Rule of the Lie derivative, which displays the Lie derivative's relationship with wedge product in the smooth case. In the discrete case, if the algebraic definition of the interior product is used, this relationship might not always be correct. This is because the algebraic interior product is defined using the wedge product. As the wedge product is only associative on closed forms (in the discrete setting), there may be errors in this property.
 
@@ -659,12 +727,12 @@ Section 10 (pp. 25-26)
 
 #### Decapodes.jl
 
-    :Δ₀ => add_De_Rham_1D!(Val{0}, ...)  
+    :Δ₀ => add_De_Rham_1D!(Val{0}, ...)
     :Δ₁ => add_De_Rham_1D!(Val{1}, ...) or add_De_Rham_2D!(Val{1}, ...)
     :Δ₂ => add_De_Rham_2D!(Val{2}, ...)
-    :Δᵈ₀ => Δᵈ(Val{0}, sd)               
-    :Δᵈ₁ => Δᵈ(Val{1}, sd)              
-    :Δ₀⁻¹ => dec_inv_lap_solver(Val{0}, sd)  
+    :Δᵈ₀ => Δᵈ(Val{0}, sd)
+    :Δᵈ₁ => Δᵈ(Val{1}, sd)
+    :Δ₀⁻¹ => dec_inv_lap_solver(Val{0}, sd)
 
 #### CombinatorialSpaces.jl
 
@@ -688,28 +756,33 @@ Section 10 (pp. 25-26)
     Δᵈ(::Type{Val{1}}, s::SimplicialSets.HasDeltaSet)
     dec_Δ⁻¹(::Type{Val{0}}, s::AbstractGeometricMapSeries; scheme::AbstractSubdivisionScheme = BinarySubdivision(), steps = 3, cycles = 5, alg = cg, μ = 2)
 
-
 ### Description
 
-The Laplacian operator, or the Laplace-Beltrami operator on 0-forms, generalizes the traditional Laplacian onto curved surfaces. It linearly maps k-forms to k-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the points surrounding it. A positive Laplacian implies that the point is less than the surrounding average (or concave up), while a negative one implies the point is greater than the surrounding average (or concave up).
+The Laplacian operator, or the Laplace-Beltrami operator on 0-forms, generalizes the traditional Laplacian to curved surfaces. It linearly maps ``k``-forms to ``k``-forms. The ordinary Laplacian determines how much a point in a function deviates from the average of the points surrounding it. With the positive-semidefinite sign convention used in this code, a positive Laplacian indicates that the point lies below the local average, while a negative Laplacian indicates that it lies above the local average.
 
-This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies from $ \Delta = \delta d + d \delta $ to $ δd $, as the codifferential of a 0-form is always zero.
+This operator is defined with the exterior derivative and codifferential operators. For 0-forms (scalars), this operator simplifies from ``\Delta = \delta d + d \delta`` to ``\delta d``, as the codifferential of a 0-form is always zero.
 
-It is represented as a sparse matrix. Due to its reliance on the codifferential (and thus the Hodge star), it is metric-dependent. 
+It is represented as a sparse matrix. Due to its reliance on the codifferential, and thus the Hodge star, it is metric-dependent.
 
 ### Important Properties
 
-$ \Delta^k:\Omega^k\_d (K) \rightarrow \Omega^k\_d (K) $
+```math
+\Delta^k : \Omega_d^k(K) \to \Omega_d^k(K)
+```
 
-The discrete Laplace-deRham operator, the general form of the Laplace-Beltrami, maps k-forms on discrete mesh K to k-forms on the same mesh.
+The discrete Laplace-deRham operator, the general form of the Laplace-Beltrami operator, maps ``k``-forms on discrete mesh ``K`` to ``k``-forms on the same mesh.
 
-$ Δ = dδ + δd $
+```math
+\Delta = d\delta + \delta d
+```
 
-This is the general Laplace-deRham Operator, which converts k-forms to dimensionally equivalent k-forms in the smooth case. The Laplace-Beltrami operator, $ \Delta f=δdf $, is a special situation for 0-forms where $ d(δf) = 0 $, as the codifferential of a 0-form is always zero.
+This is the general Laplace-deRham operator, which maps ``k``-forms to dimensionally equivalent ``k``-forms in the smooth case. The Laplace-Beltrami operator, ``\Delta f = \delta d f``, is a special case for 0-forms where ``d(\delta f) = 0``, since the codifferential of a 0-form is always zero.
 
-$ ⟨Δf, σ^0 ⟩ = \frac{1}{ |\sigma\_o| }  ∑\_{ σ^1=[σ^0, v] } \frac{|⋆σ^1 |}{|σ^1 |} (f(v) − f(σ^0)) $
+```math
+\langle \Delta f, \sigma^0 \rangle = \frac{1}{|\star \sigma_0|} \sum_{\sigma^1 = [\sigma^0, v]} \frac{|\star \sigma^1|}{|\sigma^1|} (f(v) - f(\sigma^0))
+```
 
-This formula above showcases the evaluation of a 0-form (f) at a primal vertex (σ^0) on a well-orientated triangular mesh. The mesh does not need to be flat. The formula states that the Laplacian of a 0-form f at a vertex $σ^0$,  $(⟨Δf, σ^0 ⟩)$ can be evaluated by the sum/contribution of all edges bordering $σ^0$, each weighted by the length of their corresponding dual edge divded by their primal length $(|⋆σ^1 |/|σ^1 | )$, and then multiplied by the difference between the form at the evaluated vertex $(f(σ^0))$ and the neighboring vertex $(f(v))$, connected by the edge. Then, the result of the weighted sum is divided by the volume/area of the vertice's coresponding dual cell $(1/|⋆σ^0 | )$ to normalize it. This formula was found to be equivalent with a different geometric Laplace-Beltrami formula that uses cotangents and indices.
+This formula evaluates a 0-form ``f`` at a primal vertex ``\sigma^0`` on a well-oriented triangular mesh. The mesh does not need to be flat. It states that ``\langle \Delta f, \sigma^0 \rangle`` is computed by summing the contributions of all edges incident to ``\sigma^0``, weighting each contribution by the ratio ``|\star \sigma^1| / |\sigma^1|``, multiplying by the difference ``f(v) - f(\sigma^0)``, and then normalizing by the area of the corresponding dual cell ``|\star \sigma^0|``. This formula is equivalent to a different geometric Laplace-Beltrami formula that uses cotangents and indices.
 
 ### Citations
 
@@ -727,4 +800,4 @@ Section 10 (pp. 26-27)
 
 [Notes on Discrete Exterior Calculus](https://math.arizona.edu/~agillette/research/decNotes.pdf) - Gillette
 
-[Discrete Differential Forms for Computational Modeling](https://geometry.caltech.edu/pubs/DKT05.pdf) - Desbrun et. al.  
+[Discrete Differential Forms for Computational Modeling](https://geometry.caltech.edu/pubs/DKT05.pdf) - Desbrun et. al.


### PR DESCRIPTION
This is documentation giving a simplified description of the operators in Discrete Exterior Calculus. It covers the boundary, exterior derivative, wedge product, hodge star, flat, sharp, codifferential, interior product, lie derivative, and Laplacian operators. Each section includes each operator's code signature, a short description, its important properties, and the information's source(s). 